### PR TITLE
Bur 164 frontend litus o auth v2

### DIFF
--- a/frontend/src/app/api/data/route.tsx
+++ b/frontend/src/app/api/data/route.tsx
@@ -1,0 +1,27 @@
+// app/api/data/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import axios from 'axios';
+
+export async function GET(req: NextRequest) {
+    try {
+        // Extract the auth token from cookies
+        const jwt = req.cookies.get('jwt')?.value;
+
+        if (!jwt) {
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+        }
+
+        // Make the API request with the bearer token
+        const response = await axios.get(process.env.NEXT_PUBLIC_BACKEND_URL + "/api/users/1", {
+            headers: {
+                Authorization: `Bearer ${jwt}`,
+            },
+        });
+
+        // Return the data from the API
+        return NextResponse.json(response.data);
+    } catch (error) {
+        // @ts-ignore
+        return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+}

--- a/frontend/src/app/api/proxy/route.tsx
+++ b/frontend/src/app/api/proxy/route.tsx
@@ -3,25 +3,26 @@ import axios from 'axios';
 
 export async function POST(req: NextRequest) {
     try {
-        const { method, url, body } = await req.json();
+        const { method, url, body, headers: customHeaders } = await req.json();
 
         // Extract the auth token from cookies
         const jwt = req.cookies.get('jwt')?.value;
 
-        console.log(jwt);
-
         if (!jwt) {
-            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+            return NextResponse.json({ error: 'Unauthorized: No JWT token found' }, { status: 401 });
         }
+
+        // Merge the custom headers with the Authorization header
+        const headers = {
+            ...customHeaders,
+            Authorization: `Bearer ${jwt}`,
+        };
 
         // Create Axios config
         const config = {
             method,
             url,
-            headers: {
-                Authorization: `Bearer ${jwt}`,
-                'Content-Type': 'application/json',
-            },
+            headers,
             data: body,
         };
 

--- a/frontend/src/app/api/proxy/route.tsx
+++ b/frontend/src/app/api/proxy/route.tsx
@@ -1,24 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server';
 import axios from 'axios';
 
+/**
+ * Proxy for outgoing request which retrieves the JWT token from http-only cookie and sets it as bearer token in the
+ * authorization header before executing the request.
+ */
 export async function POST(req: NextRequest) {
     try {
         const { method, url, body, headers: customHeaders } = await req.json();
 
-        // Extract the auth token from cookies
         const jwt = req.cookies.get('jwt')?.value;
-
         if (!jwt) {
             return NextResponse.json({ error: 'Unauthorized: No JWT token found' }, { status: 401 });
         }
 
-        // Merge the custom headers with the Authorization header
         const headers = {
             ...customHeaders,
             Authorization: `Bearer ${jwt}`,
         };
 
-        // Create Axios config
         const config = {
             method,
             url,
@@ -26,13 +26,10 @@ export async function POST(req: NextRequest) {
             data: body,
         };
 
-        // Make the API request with the bearer token
         const response = await axios(config);
 
-        // Return the data from the API
         return NextResponse.json(response.data);
-    } catch (error) {
-        // @ts-ignore
-        return NextResponse.json({ error: error.message }, { status: 500 });
+    } catch (err) {
+        return NextResponse.json({ error: err.message }, { status: 500 });
     }
 }

--- a/frontend/src/app/api/proxy/route.tsx
+++ b/frontend/src/app/api/proxy/route.tsx
@@ -1,22 +1,32 @@
-// app/api/data/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 import axios from 'axios';
 
-export async function GET(req: NextRequest) {
+export async function POST(req: NextRequest) {
     try {
+        const { method, url, body } = await req.json();
+
         // Extract the auth token from cookies
         const jwt = req.cookies.get('jwt')?.value;
+
+        console.log(jwt);
 
         if (!jwt) {
             return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
         }
 
-        // Make the API request with the bearer token
-        const response = await axios.get(process.env.NEXT_PUBLIC_BACKEND_URL + "/api/users/1", {
+        // Create Axios config
+        const config = {
+            method,
+            url,
             headers: {
                 Authorization: `Bearer ${jwt}`,
+                'Content-Type': 'application/json',
             },
-        });
+            data: body,
+        };
+
+        // Make the API request with the bearer token
+        const response = await axios(config);
 
         // Return the data from the API
         return NextResponse.json(response.data);

--- a/frontend/src/app/oauth/callback/page.tsx
+++ b/frontend/src/app/oauth/callback/page.tsx
@@ -1,4 +1,4 @@
 'use client';
-import {LitusOAuthCallback} from "@/components/login/LitusOAuthHelper";
+import {LitusOAuthCallback} from "@/utils/oauth";
 
 export default LitusOAuthCallback;

--- a/frontend/src/app/request/page.tsx
+++ b/frontend/src/app/request/page.tsx
@@ -1,7 +1,7 @@
-// app/home/page.tsx
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import { apiClient } from '@/utils/api';
 
 const HomePage: React.FC = () => {
     const [data, setData] = useState<any>(null);
@@ -10,11 +10,7 @@ const HomePage: React.FC = () => {
     useEffect(() => {
         const fetchData = async () => {
             try {
-                const response = await fetch('/api/data');
-                if (!response.ok) {
-                    throw new Error(`Error: ${response.statusText}`);
-                }
-                const result = await response.json();
+                const result = await apiClient('GET', '/api/users/1');
                 setData(result);
             } catch (err) {
                 // @ts-ignore

--- a/frontend/src/app/request/page.tsx
+++ b/frontend/src/app/request/page.tsx
@@ -22,7 +22,7 @@ const HomePage: React.FC = () => {
     }, []);
 
     if (error) {
-        return <div>Error: {error}</div>;
+        return <div>{error}</div>;
     }
 
     if (!data) {

--- a/frontend/src/app/request/page.tsx
+++ b/frontend/src/app/request/page.tsx
@@ -1,0 +1,44 @@
+// app/home/page.tsx
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+const HomePage: React.FC = () => {
+    const [data, setData] = useState<any>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                const response = await fetch('/api/data');
+                if (!response.ok) {
+                    throw new Error(`Error: ${response.statusText}`);
+                }
+                const result = await response.json();
+                setData(result);
+            } catch (err) {
+                // @ts-ignore
+                setError(err.message);
+            }
+        };
+
+        fetchData();
+    }, []);
+
+    if (error) {
+        return <div>Error: {error}</div>;
+    }
+
+    if (!data) {
+        return <div>Loading...</div>;
+    }
+
+    return (
+        <div>
+            <h1>Welcome to the Home Page</h1>
+            <p>Data: {JSON.stringify(data)}</p>
+        </div>
+    );
+};
+
+export default HomePage;

--- a/frontend/src/app/request/page.tsx
+++ b/frontend/src/app/request/page.tsx
@@ -3,7 +3,13 @@
 import React, { useEffect, useState } from 'react';
 import { apiClient } from '@/utils/api';
 
-const HomePage: React.FC = () => {
+/**
+ * This is a temporary component that shows how to use the apiClient to request data from the backend.
+ * It should be removed later.
+ *
+ * TODO: remove after apiClient is used in other places
+ */
+const Page: React.FC = () => {
     const [data, setData] = useState<any>(null);
     const [error, setError] = useState<string | null>(null);
 
@@ -13,7 +19,6 @@ const HomePage: React.FC = () => {
                 const result = await apiClient('GET', '/api/users/1');
                 setData(result);
             } catch (err) {
-                // @ts-ignore
                 setError(err.message);
             }
         };
@@ -31,10 +36,9 @@ const HomePage: React.FC = () => {
 
     return (
         <div>
-            <h1>Welcome to the Home Page</h1>
             <p>Data: {JSON.stringify(data)}</p>
         </div>
     );
 };
 
-export default HomePage;
+export default Page;

--- a/frontend/src/components/login/LitusOAuthButton.tsx
+++ b/frontend/src/components/login/LitusOAuthButton.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect} from "react";
 import Image from "next/image";
 import {useRouter} from "next/navigation";
-import {initiateLitusOAuthFlow} from "@/components/login/LitusOAuthHelper";
+import {initiateLitusOAuthFlow} from "@/utils/LitusOAuthHelper";
 
 
 const LitusOAuthButton = () => {

--- a/frontend/src/components/login/LitusOAuthButton.tsx
+++ b/frontend/src/components/login/LitusOAuthButton.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect} from "react";
 import Image from "next/image";
 import {useRouter} from "next/navigation";
-import {initiateLitusOAuthFlow} from "@/utils/LitusOAuthHelper";
+import {initiateLitusOAuthFlow} from "@/utils/oauth";
 
 
 const LitusOAuthButton = () => {

--- a/frontend/src/utils/api.tsx
+++ b/frontend/src/utils/api.tsx
@@ -1,0 +1,23 @@
+export const apiClient = async (method: string, endpoint: string, body?: any) => {
+    const baseUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+    if (!baseUrl) {
+        throw new Error(`Missing environment variable for backend base URL`)
+    }
+
+    const url = baseUrl + endpoint;
+
+    const response = await fetch('/api/proxy', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ method, url, body }),
+    });
+
+    if (!response.ok) {
+        throw new Error(`Error: ${response.statusText}`);
+    }
+
+    return response.json();
+};

--- a/frontend/src/utils/api.tsx
+++ b/frontend/src/utils/api.tsx
@@ -1,4 +1,6 @@
-// app/utils/apiClient.ts
+/**
+ * API Client for requests to the backend server.
+ */
 export const apiClient = async (method: string, endpoint: string, body?: any, headers?: Record<string, string>) => {
     const baseUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 
@@ -8,6 +10,7 @@ export const apiClient = async (method: string, endpoint: string, body?: any, he
 
     const url = baseUrl + endpoint;
 
+    // Execute request via proxy
     const response = await fetch('/api/proxy', {
         method: 'POST',
         headers: {

--- a/frontend/src/utils/api.tsx
+++ b/frontend/src/utils/api.tsx
@@ -1,4 +1,5 @@
-export const apiClient = async (method: string, endpoint: string, body?: any) => {
+// app/utils/apiClient.ts
+export const apiClient = async (method: string, endpoint: string, body?: any, headers?: Record<string, string>) => {
     const baseUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 
     if (!baseUrl) {
@@ -12,7 +13,7 @@ export const apiClient = async (method: string, endpoint: string, body?: any) =>
         headers: {
             'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ method, url, body }),
+        body: JSON.stringify({ method, url, body, headers }),
     });
 
     if (!response.ok) {

--- a/frontend/src/utils/api.tsx
+++ b/frontend/src/utils/api.tsx
@@ -10,7 +10,7 @@ export const apiClient = async (method: string, endpoint: string, body?: any, he
 
     const url = baseUrl + endpoint;
 
-    // Execute request via proxy
+    // Execute request via proxy that adds JWT
     const response = await fetch('/api/proxy', {
         method: 'POST',
         headers: {

--- a/frontend/src/utils/oauth.tsx
+++ b/frontend/src/utils/oauth.tsx
@@ -8,6 +8,7 @@ import axios from "axios";
  * Encode binary buffer to base64url
  */
 function base64URLEncode(buffer : crypto.BinaryLike) {
+    // @ts-ignore
     return buffer.toString("base64")
         .replace(/\+/g, '-')
         .replace(/\//g, '_')

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -4,6 +4,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "useUnknownInCatchVariables": false,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
With the previous PR of BUR-164, the jwt was successfully received and stored in http-only cookie. However, the backend requires it to be delivered in a bearer token. This PR solves that issue and also includes a temporary component for manual testing, which i propose we leave there until we have other components actually using backend endpoints.