### PR TITLE
BUR-401 update Next.js to v16.0.7

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,11 +30,11 @@
         "lucide-react": "^0.554.0",
         "next": "^16.0.7",
         "next-i18n-router": "^5.5.1",
-        "react": "^19.2.0",
-        "react-dom": "^19.2.0",
-        "react-hook-form": "^7.53.1",
+        "react": "^19.2.1",
+        "react-dom": "^19.2.1",
+        "react-hook-form": "^7.68.0",
         "react-hotkeys-hook": "^5.2.1",
-        "react-i18next": "^16.3.5",
+        "react-i18next": "^16.4.0",
         "react-loading-skeleton": "^3.5.0",
         "react-pdf": "^10.2.0",
         "sharp": "^0.34.5",
@@ -47,7 +47,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.17",
         "@types/node": "^24",
-        "@types/react": "^19.2.6",
+        "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "eslint": "^9",
         "eslint-config-next": "^16.0.3",
@@ -5026,9 +5026,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-p/jUvulfgU7oKtj6Xpk8cA2Y1xKTtICGpJYeJXz2YVO2UcvjQgeRMLDGfDeqeRW2Ta+0QNFwcc8X3GH8SxZz6w==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -9879,24 +9879,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
-      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
+      "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
+      "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.0"
+        "react": "^19.2.1"
       }
     },
     "node_modules/react-error-boundary": {
@@ -9912,9 +9912,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.66.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.66.1.tgz",
-      "integrity": "sha512-2KnjpgG2Rhbi+CIiIBQQ9Df6sMGH5ExNyFl4Hw9qO7pIqMBR8Bvu9RQyjl3JM4vehzCh9soiNUM/xYMswb2EiA==",
+      "version": "7.68.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.68.0.tgz",
+      "integrity": "sha512-oNN3fjrZ/Xo40SWlHf1yCjlMK417JxoSJVUXQjGdvdRCU07NTFei1i1f8ApUAts+IVh14e4EdakeLEA+BEAs/Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -9941,9 +9941,9 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "16.3.5",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.3.5.tgz",
-      "integrity": "sha512-F7Kglc+T0aE6W2rO5eCAFBEuWRpNb5IFmXOYEgztjZEuiuSLTe/xBIEG6Q3S0fbl8GXMNo+Q7gF8bpokFNWJww==",
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.4.0.tgz",
+      "integrity": "sha512-bxVeBA8Ky2UeItNhF4JRxHCFIrpEJHGFG/mOAa4CR0JkqaDEYSLmlEgmC4Os63SBlZ+E5U0YyrNJOSVl2mtVqQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,11 +31,11 @@
     "lucide-react": "^0.554.0",
     "next": "^16.0.7",
     "next-i18n-router": "^5.5.1",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.0",
-    "react-hook-form": "^7.53.1",
+    "react": "^19.2.1",
+    "react-dom": "^19.2.1",
+    "react-hook-form": "^7.68.0",
     "react-hotkeys-hook": "^5.2.1",
-    "react-i18next": "^16.3.5",
+    "react-i18next": "^16.4.0",
     "react-loading-skeleton": "^3.5.0",
     "react-pdf": "^10.2.0",
     "sharp": "^0.34.5",
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.17",
     "@types/node": "^24",
-    "@types/react": "^19.2.6",
+    "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "eslint": "^9",
     "eslint-config-next": "^16.0.3",
@@ -56,9 +56,5 @@
     "postcss": "^8.4.38",
     "tailwindcss": "^4.1.17",
     "typescript": "^5"
-  },
-  "overrides": {
-    "@types/react": "^19.2.6",
-    "@types/react-dom": "^19.2.3"
   }
 }


### PR DESCRIPTION
A critical vulnerability in React Server Components (CVE-2025-55182) has been responsibly disclosed. It affects React 19 and frameworks that use it, including Next.js (CVE-2025-66478).

If you are using Next.js, every version between Next.js 15 and 16 is affected, and we recommend immediately updating to the latest Next.js versions containing the appropriate fixes (15.0.5, 15.1.9, 15.2.6, 15.3.6, 15.4.8, 15.5.7, 16.0.7).

If you are using another framework using Server Components, we also recommend immediately updating to the latest React versions containing the appropriate fixes (19.0.1, 19.1.2, and 19.2.1)

https://nextjs.org/blog/CVE-2025-66478