### PR TITLE
BUR-396 disable permissions policy

### DIFF
--- a/backend/config/packages/nelmio_security.yaml
+++ b/backend/config/packages/nelmio_security.yaml
@@ -28,6 +28,10 @@ nelmio_security:
             style-src: [ 'self', 'unsafe-inline', 'data:' ]
             img-src: [ 'self', 'data:' ]
 
+    # Permissions Policy - control access to browser features
+    permissions_policy:
+        enabled: false
+
     # Forced HTTPS/SSL with HSTS (HTTP Strict Transport Security)
     forced_ssl:
         enabled: true


### PR DESCRIPTION
This pull request introduces a configuration change to the `nelmio_security.yaml` file, specifically related to browser security policies. The main update is the addition of a `permissions_policy` section, which is currently disabled.

Security configuration update:

* Added a `permissions_policy` section to control access to browser features, but left it disabled by setting `enabled: false`. This sets up the configuration for future use without affecting current behavior.