### PR TITLE
BUR-420 let all entities extend BaseEntity with id, createdAt and updatedAt

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -50,7 +50,7 @@ TEMP_FILE=$(mktemp)
 echo "$STAGED_FILES" > "$TEMP_FILE"
 
 # Run phpcs on staged files
-PHPCS_OUTPUT=$(cd "$GIT_ROOT" && cat "$TEMP_FILE" | xargs "$PHPCS" --runtime-set ignore_warnings_on_exit 1 2>&1)
+PHPCS_OUTPUT=$(cd "$GIT_ROOT" && cat "$TEMP_FILE" | xargs "$PHPCS" --standard="$BACKEND_DIR/phpcs.xml.dist" --runtime-set ignore_warnings_on_exit 1 2>&1)
 PHPCS_EXIT_CODE=$?
 
 # Clean up temp file

--- a/backend/config/packages/doctrine.yaml
+++ b/backend/config/packages/doctrine.yaml
@@ -17,8 +17,7 @@ doctrine:
                 dir: '%kernel.project_dir%/src/Entity'
                 prefix: 'App\Entity'
                 alias: App
-        controller_resolver:
-            auto_mapping: false
+
 
 when@test:
     doctrine:

--- a/backend/config/packages/doctrine.yaml
+++ b/backend/config/packages/doctrine.yaml
@@ -29,8 +29,6 @@ when@test:
 when@prod:
     doctrine:
         orm:
-            auto_generate_proxy_classes: false
-            proxy_dir: '%kernel.build_dir%/doctrine/orm/Proxies'
             query_cache_driver:
                 type: pool
                 pool: doctrine.system_cache_pool

--- a/backend/config/packages/sentry.yaml
+++ b/backend/config/packages/sentry.yaml
@@ -15,6 +15,8 @@ when@prod:
         options:
             # Set custom Sentry environment
             environment: "backend-%kernel.environment%"
+            # Required for LogsHandler (Sentry Logs API)
+            enable_logs: true
             # Ignore 404 errors
             ignore_exceptions:
                 - Symfony\Component\HttpKernel\Exception\NotFoundHttpException
@@ -22,12 +24,13 @@ when@prod:
     monolog:
         handlers:
             sentry:
-                type: sentry
-                level: !php/const Monolog\Logger::ERROR
-                hub_id: Sentry\State\HubInterface
+                type: service
+                id: Sentry\Monolog\LogsHandler
 
-    # Uncomment these lines to register a log message processor that resolves PSR-3 placeholders
-    # https://docs.sentry.io/platforms/php/guides/symfony/#monolog-integration
     services:
+        Sentry\Monolog\LogsHandler:
+            arguments:
+                $logLevel: !php/const Monolog\Logger::ERROR
+
         Monolog\Processor\PsrLogMessageProcessor:
             tags: { name: monolog.processor, handler: sentry }

--- a/backend/migrations/Version20260411183148.php
+++ b/backend/migrations/Version20260411183148.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260411183148 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        // Tables with existing create_date/update_date columns - migrate data
+        $this->addSql('ALTER TABLE announcement ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE announcement ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE announcement SET created_at = create_date, updated_at = update_date');
+        $this->addSql('ALTER TABLE announcement ALTER COLUMN created_at SET NOT NULL');
+        $this->addSql('ALTER TABLE announcement ALTER COLUMN updated_at SET NOT NULL');
+        $this->addSql('ALTER TABLE announcement DROP create_date');
+        $this->addSql('ALTER TABLE announcement DROP update_date');
+
+        $this->addSql('ALTER TABLE burgieclan_user ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE burgieclan_user ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE burgieclan_user SET created_at = NOW(), updated_at = NOW()');
+        $this->addSql('ALTER TABLE burgieclan_user ALTER COLUMN created_at SET NOT NULL');
+        $this->addSql('ALTER TABLE burgieclan_user ALTER COLUMN updated_at SET NOT NULL');
+
+        $this->addSql('ALTER TABLE comment_category ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE comment_category ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE comment_category SET created_at = NOW(), updated_at = NOW()');
+        $this->addSql('ALTER TABLE comment_category ALTER COLUMN created_at SET NOT NULL');
+        $this->addSql('ALTER TABLE comment_category ALTER COLUMN updated_at SET NOT NULL');
+
+        $this->addSql('ALTER TABLE course ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE course ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE course SET created_at = NOW(), updated_at = NOW()');
+        $this->addSql('ALTER TABLE course ALTER COLUMN created_at SET NOT NULL');
+        $this->addSql('ALTER TABLE course ALTER COLUMN updated_at SET NOT NULL');
+
+        $this->addSql('ALTER TABLE course_comment ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE course_comment ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE course_comment SET created_at = create_date, updated_at = update_date');
+        $this->addSql('ALTER TABLE course_comment ALTER COLUMN created_at SET NOT NULL');
+        $this->addSql('ALTER TABLE course_comment ALTER COLUMN updated_at SET NOT NULL');
+        $this->addSql('ALTER TABLE course_comment DROP create_date');
+        $this->addSql('ALTER TABLE course_comment DROP update_date');
+
+        $this->addSql('ALTER TABLE course_comment_vote ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE course_comment_vote ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE course_comment_vote SET created_at = create_date, updated_at = update_date');
+        $this->addSql('ALTER TABLE course_comment_vote ALTER COLUMN created_at SET NOT NULL');
+        $this->addSql('ALTER TABLE course_comment_vote ALTER COLUMN updated_at SET NOT NULL');
+        $this->addSql('ALTER TABLE course_comment_vote DROP create_date');
+        $this->addSql('ALTER TABLE course_comment_vote DROP update_date');
+
+        $this->addSql('ALTER TABLE document ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE document ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE document SET created_at = create_date, updated_at = update_date');
+        $this->addSql('ALTER TABLE document ALTER COLUMN created_at SET NOT NULL');
+        $this->addSql('ALTER TABLE document ALTER COLUMN updated_at SET NOT NULL');
+        $this->addSql('ALTER TABLE document DROP create_date');
+        $this->addSql('ALTER TABLE document DROP update_date');
+
+        $this->addSql('ALTER TABLE document_category ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE document_category ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE document_category SET created_at = NOW(), updated_at = NOW()');
+        $this->addSql('ALTER TABLE document_category ALTER COLUMN created_at SET NOT NULL');
+        $this->addSql('ALTER TABLE document_category ALTER COLUMN updated_at SET NOT NULL');
+
+
+        $this->addSql('ALTER TABLE document_comment ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE document_comment ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE document_comment SET created_at = create_date, updated_at = update_date');
+        $this->addSql('ALTER TABLE document_comment ALTER COLUMN created_at SET NOT NULL');
+        $this->addSql('ALTER TABLE document_comment ALTER COLUMN updated_at SET NOT NULL');
+        $this->addSql('ALTER TABLE document_comment DROP create_date');
+        $this->addSql('ALTER TABLE document_comment DROP update_date');
+
+        $this->addSql('ALTER TABLE document_comment_vote ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE document_comment_vote ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE document_comment_vote SET created_at = create_date, updated_at = update_date');
+        $this->addSql('ALTER TABLE document_comment_vote ALTER COLUMN created_at SET NOT NULL');
+        $this->addSql('ALTER TABLE document_comment_vote ALTER COLUMN updated_at SET NOT NULL');
+        $this->addSql('ALTER TABLE document_comment_vote DROP create_date');
+        $this->addSql('ALTER TABLE document_comment_vote DROP update_date');
+
+        $this->addSql('ALTER TABLE document_vote ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE document_vote ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE document_vote SET created_at = create_date, updated_at = update_date');
+        $this->addSql('ALTER TABLE document_vote ALTER COLUMN created_at SET NOT NULL');
+        $this->addSql('ALTER TABLE document_vote ALTER COLUMN updated_at SET NOT NULL');
+        $this->addSql('ALTER TABLE document_vote DROP create_date');
+        $this->addSql('ALTER TABLE document_vote DROP update_date');
+
+        $this->addSql('ALTER TABLE module ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE module ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE module SET created_at = NOW(), updated_at = NOW()');
+        $this->addSql('ALTER TABLE module ALTER COLUMN created_at SET NOT NULL');
+        $this->addSql('ALTER TABLE module ALTER COLUMN updated_at SET NOT NULL');
+
+        $this->addSql('ALTER TABLE page ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE page ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE page SET created_at = NOW(), updated_at = NOW()');
+        $this->addSql('ALTER TABLE page ALTER COLUMN created_at SET NOT NULL');
+        $this->addSql('ALTER TABLE page ALTER COLUMN updated_at SET NOT NULL');
+
+        $this->addSql('ALTER TABLE program ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE program ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE program SET created_at = NOW(), updated_at = NOW()');
+        $this->addSql('ALTER TABLE program ALTER COLUMN created_at SET NOT NULL');
+        $this->addSql('ALTER TABLE program ALTER COLUMN updated_at SET NOT NULL');
+
+        $this->addSql('ALTER TABLE quick_link ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE quick_link ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE quick_link SET created_at = NOW(), updated_at = NOW()');
+        $this->addSql('ALTER TABLE quick_link ALTER COLUMN created_at SET NOT NULL');
+        $this->addSql('ALTER TABLE quick_link ALTER COLUMN updated_at SET NOT NULL');
+
+        $this->addSql('ALTER TABLE tag ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE tag ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE tag SET created_at = NOW(), updated_at = NOW()');
+        $this->addSql('ALTER TABLE tag ALTER COLUMN created_at SET NOT NULL');
+        $this->addSql('ALTER TABLE tag ALTER COLUMN updated_at SET NOT NULL');
+
+        $this->addSql('ALTER TABLE user_document_view ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE user_document_view ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE user_document_view SET created_at = NOW(), updated_at = NOW()');
+        $this->addSql('ALTER TABLE user_document_view ALTER COLUMN created_at SET NOT NULL');
+        $this->addSql('ALTER TABLE user_document_view ALTER COLUMN updated_at SET NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        // Tables with existing create_date/update_date columns -> migrate data back
+        // Tables without existing create_date/update_date -> just drop the new columns
+
+        $this->addSql('ALTER TABLE announcement ADD create_date TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE announcement ADD update_date TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE announcement SET create_date = created_at, update_date = updated_at');
+        $this->addSql('ALTER TABLE announcement ALTER COLUMN create_date SET NOT NULL');
+        $this->addSql('ALTER TABLE announcement ALTER COLUMN update_date SET NOT NULL');
+        $this->addSql('ALTER TABLE announcement DROP created_at');
+        $this->addSql('ALTER TABLE announcement DROP updated_at');
+
+        $this->addSql('ALTER TABLE burgieclan_user DROP created_at');
+        $this->addSql('ALTER TABLE burgieclan_user DROP updated_at');
+
+        $this->addSql('ALTER TABLE comment_category DROP created_at');
+        $this->addSql('ALTER TABLE comment_category DROP updated_at');
+
+        $this->addSql('ALTER TABLE course DROP created_at');
+        $this->addSql('ALTER TABLE course DROP updated_at');
+
+        $this->addSql('ALTER TABLE course_comment ADD create_date TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE course_comment ADD update_date TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE course_comment SET create_date = created_at, update_date = updated_at');
+        $this->addSql('ALTER TABLE course_comment ALTER COLUMN create_date SET NOT NULL');
+        $this->addSql('ALTER TABLE course_comment ALTER COLUMN update_date SET NOT NULL');
+        $this->addSql('ALTER TABLE course_comment DROP created_at');
+        $this->addSql('ALTER TABLE course_comment DROP updated_at');
+
+        $this->addSql('ALTER TABLE course_comment_vote ADD create_date TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE course_comment_vote ADD update_date TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE course_comment_vote SET create_date = created_at, update_date = updated_at');
+        $this->addSql('ALTER TABLE course_comment_vote ALTER COLUMN create_date SET NOT NULL');
+        $this->addSql('ALTER TABLE course_comment_vote ALTER COLUMN update_date SET NOT NULL');
+        $this->addSql('ALTER TABLE course_comment_vote DROP created_at');
+        $this->addSql('ALTER TABLE course_comment_vote DROP updated_at');
+
+        $this->addSql('ALTER TABLE document ADD create_date TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE document ADD update_date TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE document SET create_date = created_at, update_date = updated_at');
+        $this->addSql('ALTER TABLE document ALTER COLUMN create_date SET NOT NULL');
+        $this->addSql('ALTER TABLE document ALTER COLUMN update_date SET NOT NULL');
+        $this->addSql('ALTER TABLE document DROP created_at');
+        $this->addSql('ALTER TABLE document DROP updated_at');
+
+        $this->addSql('ALTER TABLE document_category DROP created_at');
+        $this->addSql('ALTER TABLE document_category DROP updated_at');
+
+        $this->addSql('ALTER TABLE document_comment ADD create_date TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE document_comment ADD update_date TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE document_comment SET create_date = created_at, update_date = updated_at');
+        $this->addSql('ALTER TABLE document_comment ALTER COLUMN create_date SET NOT NULL');
+        $this->addSql('ALTER TABLE document_comment ALTER COLUMN update_date SET NOT NULL');
+        $this->addSql('ALTER TABLE document_comment DROP created_at');
+        $this->addSql('ALTER TABLE document_comment DROP updated_at');
+
+        $this->addSql('ALTER TABLE document_comment_vote ADD create_date TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE document_comment_vote ADD update_date TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE document_comment_vote SET create_date = created_at, update_date = updated_at');
+        $this->addSql('ALTER TABLE document_comment_vote ALTER COLUMN create_date SET NOT NULL');
+        $this->addSql('ALTER TABLE document_comment_vote ALTER COLUMN update_date SET NOT NULL');
+        $this->addSql('ALTER TABLE document_comment_vote DROP created_at');
+        $this->addSql('ALTER TABLE document_comment_vote DROP updated_at');
+
+        $this->addSql('ALTER TABLE document_vote ADD create_date TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('ALTER TABLE document_vote ADD update_date TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->addSql('UPDATE document_vote SET create_date = created_at, update_date = updated_at');
+        $this->addSql('ALTER TABLE document_vote ALTER COLUMN create_date SET NOT NULL');
+        $this->addSql('ALTER TABLE document_vote ALTER COLUMN update_date SET NOT NULL');
+        $this->addSql('ALTER TABLE document_vote DROP created_at');
+        $this->addSql('ALTER TABLE document_vote DROP updated_at');
+
+        $this->addSql('ALTER TABLE module DROP created_at');
+        $this->addSql('ALTER TABLE module DROP updated_at');
+
+        $this->addSql('ALTER TABLE page DROP created_at');
+        $this->addSql('ALTER TABLE page DROP updated_at');
+
+        $this->addSql('ALTER TABLE program DROP created_at');
+        $this->addSql('ALTER TABLE program DROP updated_at');
+
+        $this->addSql('ALTER TABLE quick_link DROP created_at');
+        $this->addSql('ALTER TABLE quick_link DROP updated_at');
+
+        $this->addSql('ALTER TABLE tag DROP created_at');
+        $this->addSql('ALTER TABLE tag DROP updated_at');
+
+        $this->addSql('ALTER TABLE user_document_view DROP created_at');
+        $this->addSql('ALTER TABLE user_document_view DROP updated_at');
+    }
+}

--- a/backend/phpcs.xml.dist
+++ b/backend/phpcs.xml.dist
@@ -8,7 +8,10 @@
     <arg name="colors"/>
     <arg name="extensions" value="php"/>
 
-    <rule ref="PSR12"/>
+    <rule ref="PSR12">
+        <exclude name="Squiz.WhiteSpace.ScopeClosingBrace"/>
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine"/>
+    </rule>
 
     <!-- Do not allow unreachable code. -->
     <rule ref="Squiz.PHP.NonExecutableCode"/>

--- a/backend/src/ApiResource/AbstractCommentApi.php
+++ b/backend/src/ApiResource/AbstractCommentApi.php
@@ -15,9 +15,9 @@ abstract class AbstractCommentApi extends NodeApi
     #[ApiFilter(SearchFilter::class, strategy: 'ipartial')]
     #[Groups(
         [
-        SerializationGroups::COURSE_GET,
-        SerializationGroups::DOCUMENT_COMMENT_GET,
-        SerializationGroups::COURSE_COMMENT_GET
+            SerializationGroups::COURSE_GET,
+            SerializationGroups::DOCUMENT_COMMENT_GET,
+            SerializationGroups::COURSE_COMMENT_GET
         ]
     )]
     public ?string $content = null;
@@ -25,9 +25,9 @@ abstract class AbstractCommentApi extends NodeApi
     #[ApiFilter(BooleanFilter::class)]
     #[Groups(
         [
-        SerializationGroups::COURSE_GET,
-        SerializationGroups::DOCUMENT_COMMENT_GET,
-        SerializationGroups::COURSE_COMMENT_GET
+            SerializationGroups::COURSE_GET,
+            SerializationGroups::DOCUMENT_COMMENT_GET,
+            SerializationGroups::COURSE_COMMENT_GET
         ]
     )]
     public bool $anonymous = false;

--- a/backend/src/ApiResource/AbstractCommentApi.php
+++ b/backend/src/ApiResource/AbstractCommentApi.php
@@ -5,6 +5,7 @@ namespace App\ApiResource;
 use ApiPlatform\Doctrine\Orm\Filter\BooleanFilter;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Metadata\ApiFilter;
+use App\Constants\SerializationGroups;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -12,10 +13,22 @@ abstract class AbstractCommentApi extends NodeApi
 {
     #[Assert\NotBlank]
     #[ApiFilter(SearchFilter::class, strategy: 'ipartial')]
-    #[Groups(['course:get', 'document_comment:get'])]
+    #[Groups(
+        [
+        SerializationGroups::COURSE_GET,
+        SerializationGroups::DOCUMENT_COMMENT_GET,
+        SerializationGroups::COURSE_COMMENT_GET
+        ]
+    )]
     public ?string $content = null;
 
     #[ApiFilter(BooleanFilter::class)]
-    #[Groups(['course:get', 'document_comment:get'])]
+    #[Groups(
+        [
+        SerializationGroups::COURSE_GET,
+        SerializationGroups::DOCUMENT_COMMENT_GET,
+        SerializationGroups::COURSE_COMMENT_GET
+        ]
+    )]
     public bool $anonymous = false;
 }

--- a/backend/src/ApiResource/AbstractVoteApi.php
+++ b/backend/src/ApiResource/AbstractVoteApi.php
@@ -4,6 +4,7 @@ namespace App\ApiResource;
 
 use ApiPlatform\Doctrine\Orm\Filter\NumericFilter;
 use ApiPlatform\Metadata\ApiFilter;
+use App\Constants\SerializationGroups;
 use App\Entity\AbstractVote;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -16,6 +17,6 @@ abstract class AbstractVoteApi extends NodeApi
         choices: [AbstractVote::UPVOTE, AbstractVote::DOWNVOTE],
         message: 'Vote type must be either UPVOTE (1) or DOWNVOTE (-1).'
     )]
-    #[Groups(['vote:read', 'vote:write'])]
+    #[Groups([SerializationGroups::VOTE_READ, SerializationGroups::VOTE_WRITE])]
     public int $voteType;
 }

--- a/backend/src/ApiResource/AbstractVoteApi.php
+++ b/backend/src/ApiResource/AbstractVoteApi.php
@@ -4,17 +4,12 @@ namespace App\ApiResource;
 
 use ApiPlatform\Doctrine\Orm\Filter\NumericFilter;
 use ApiPlatform\Metadata\ApiFilter;
-use ApiPlatform\Metadata\ApiProperty;
 use App\Entity\AbstractVote;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 abstract class AbstractVoteApi extends NodeApi
 {
-    #[ApiProperty(readable: false, writable: false, identifier: true)]
-    #[Groups(['vote:read'])]
-    public ?int $id = null;
-
     #[ApiFilter(NumericFilter::class)]
     #[Assert\NotNull]
     #[Assert\Choice(

--- a/backend/src/ApiResource/AnnouncementApi.php
+++ b/backend/src/ApiResource/AnnouncementApi.php
@@ -60,11 +60,8 @@ use App\State\EntityClassDtoStateProvider;
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: Announcement::class),
 )]
-class AnnouncementApi
+class AnnouncementApi extends NodeApi
 {
-    #[ApiProperty(readable: false, writable: false, identifier: true)]
-    public ?int $id = null;
-
     #[ApiFilter(
         MultiLangSearchFilter::class,
         properties: [
@@ -88,12 +85,6 @@ class AnnouncementApi
 
     #[ApiFilter(DateFilter::class)]
     public string $endTime;
-
-    #[ApiProperty(writable: false)]
-    public string $createdAt;
-
-    #[ApiProperty(writable: false)]
-    public string $updatedAt;
 
     #[ApiProperty(writable: false)]
     public bool $priority;

--- a/backend/src/ApiResource/AnnouncementApi.php
+++ b/backend/src/ApiResource/AnnouncementApi.php
@@ -11,10 +11,12 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
+use App\Constants\SerializationGroups;
 use App\Entity\Announcement;
 use App\Filter\MultiLangSearchFilter;
 use App\State\EntityClassDtoStateProcessor;
 use App\State\EntityClassDtoStateProvider;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ApiResource(
     shortName: 'Announcement',
@@ -34,7 +36,8 @@ use App\State\EntityClassDtoStateProvider;
                         description: 'The language in which to retrieve the announcement content'
                     )
                 ]
-            )
+            ),
+            normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::ANNOUNCEMENT_GET]],
         ),
         new GetCollection(
             openapi: new Operation(
@@ -53,7 +56,8 @@ use App\State\EntityClassDtoStateProvider;
                         description: 'The language in which to retrieve the announcement content'
                     )
                 ]
-            )
+            ),
+            normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::ANNOUNCEMENT_GET]],
         ),
     ],
     provider: EntityClassDtoStateProvider::class,
@@ -68,6 +72,7 @@ class AnnouncementApi extends NodeApi
             'title' => ['title_nl', 'title_en'],
         ]
     )]
+    #[Groups([SerializationGroups::ANNOUNCEMENT_GET])]
     public ?string $title = null;
 
     #[ApiFilter(
@@ -76,16 +81,21 @@ class AnnouncementApi extends NodeApi
             'content' => ['content_nl', 'content_en'],
         ]
     )]
+    #[Groups([SerializationGroups::ANNOUNCEMENT_GET])]
     public ?string $content = null;
 
+    #[Groups([SerializationGroups::ANNOUNCEMENT_GET])]
     public ?UserApi $creator;
 
     #[ApiFilter(DateFilter::class)]
+    #[Groups([SerializationGroups::ANNOUNCEMENT_GET])]
     public string $startTime;
 
     #[ApiFilter(DateFilter::class)]
+    #[Groups([SerializationGroups::ANNOUNCEMENT_GET])]
     public string $endTime;
 
     #[ApiProperty(writable: false)]
+    #[Groups([SerializationGroups::ANNOUNCEMENT_GET])]
     public bool $priority;
 }

--- a/backend/src/ApiResource/AnnouncementApi.php
+++ b/backend/src/ApiResource/AnnouncementApi.php
@@ -84,9 +84,6 @@ class AnnouncementApi extends NodeApi
     #[Groups([SerializationGroups::ANNOUNCEMENT_GET])]
     public ?string $content = null;
 
-    #[Groups([SerializationGroups::ANNOUNCEMENT_GET])]
-    public ?UserApi $creator;
-
     #[ApiFilter(DateFilter::class)]
     #[Groups([SerializationGroups::ANNOUNCEMENT_GET])]
     public string $startTime;

--- a/backend/src/ApiResource/BaseEntityApi.php
+++ b/backend/src/ApiResource/BaseEntityApi.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\ApiResource;
+
+use ApiPlatform\Metadata\ApiProperty;
+use App\Constants\SerializationGroups;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+/**
+ * Base API DTO providing common fields for all entities.
+ * These fields are included in all serialization groups
+ * to ensure they are always returned in API responses.
+ */
+abstract class BaseEntityApi
+{
+    #[ApiProperty(readable: false, writable: false, identifier: true)]
+    #[Groups(SerializationGroups::ALL_READ_GROUPS)]
+    public int $id;
+
+    #[ApiProperty(writable: false)]
+    #[Groups(SerializationGroups::ALL_READ_GROUPS)]
+    public string $createdAt;
+
+    #[ApiProperty(writable: false)]
+    #[Groups(SerializationGroups::ALL_READ_GROUPS)]
+    public string $updatedAt;
+}

--- a/backend/src/ApiResource/BaseEntityApi.php
+++ b/backend/src/ApiResource/BaseEntityApi.php
@@ -8,20 +8,20 @@ use Symfony\Component\Serializer\Attribute\Groups;
 
 /**
  * Base API DTO providing common fields for all entities.
- * These fields are included in all serialization groups
- * to ensure they are always returned in API responses.
+ * These fields are included in the SerializationGroups::BASE_READ group
+ * which is added to every resource's normalizationContext.
  */
 abstract class BaseEntityApi
 {
     #[ApiProperty(readable: false, writable: false, identifier: true)]
-    #[Groups(SerializationGroups::ALL_READ_GROUPS)]
-    public int $id;
+    #[Groups([SerializationGroups::BASE_READ])]
+    public ?int $id = null;
 
     #[ApiProperty(writable: false)]
-    #[Groups(SerializationGroups::ALL_READ_GROUPS)]
+    #[Groups([SerializationGroups::BASE_READ])]
     public string $createdAt;
 
     #[ApiProperty(writable: false)]
-    #[Groups(SerializationGroups::ALL_READ_GROUPS)]
+    #[Groups([SerializationGroups::BASE_READ])]
     public string $updatedAt;
 }

--- a/backend/src/ApiResource/CommentCategoryApi.php
+++ b/backend/src/ApiResource/CommentCategoryApi.php
@@ -4,7 +4,6 @@ namespace App\ApiResource;
 
 use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata\ApiFilter;
-use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
@@ -24,11 +23,8 @@ use Symfony\Component\Validator\Constraints as Assert;
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: CommentCategory::class),
 )]
-class CommentCategoryApi
+class CommentCategoryApi extends BaseEntityApi
 {
-    #[ApiProperty(readable: false, writable: false, identifier: true)]
-    public ?int $id = null;
-
     #[Assert\NotBlank]
     #[ApiFilter(
         MultiLangSearchFilter::class,

--- a/backend/src/ApiResource/CommentCategoryApi.php
+++ b/backend/src/ApiResource/CommentCategoryApi.php
@@ -32,7 +32,7 @@ class CommentCategoryApi extends BaseEntityApi
     #[ApiFilter(
         MultiLangSearchFilter::class,
         properties: [
-        'name' => ['name_nl', 'name_en'],
+            'name' => ['name_nl', 'name_en'],
         ]
     )]
     #[Groups([SerializationGroups::COMMENT_CATEGORY_GET])]
@@ -41,7 +41,7 @@ class CommentCategoryApi extends BaseEntityApi
     #[ApiFilter(
         MultiLangSearchFilter::class,
         properties: [
-        'description' => ['description_nl', 'description_en'],
+            'description' => ['description_nl', 'description_en'],
         ]
     )]
     #[Groups([SerializationGroups::COMMENT_CATEGORY_GET])]

--- a/backend/src/ApiResource/CommentCategoryApi.php
+++ b/backend/src/ApiResource/CommentCategoryApi.php
@@ -7,10 +7,12 @@ use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use App\Constants\SerializationGroups;
 use App\Entity\CommentCategory;
 use App\Filter\MultiLangSearchFilter;
 use App\State\EntityClassDtoStateProcessor;
 use App\State\EntityClassDtoStateProvider;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
@@ -19,6 +21,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Get(),
         new GetCollection(),
     ],
+    normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::COMMENT_CATEGORY_GET]],
     provider: EntityClassDtoStateProvider::class,
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: CommentCategory::class),
@@ -32,6 +35,7 @@ class CommentCategoryApi extends BaseEntityApi
         'name' => ['name_nl', 'name_en'],
         ]
     )]
+    #[Groups([SerializationGroups::COMMENT_CATEGORY_GET])]
     public ?string $name = null;
 
     #[ApiFilter(
@@ -40,5 +44,6 @@ class CommentCategoryApi extends BaseEntityApi
         'description' => ['description_nl', 'description_en'],
         ]
     )]
+    #[Groups([SerializationGroups::COMMENT_CATEGORY_GET])]
     public ?string $description = null;
 }

--- a/backend/src/ApiResource/CourseApi.php
+++ b/backend/src/ApiResource/CourseApi.php
@@ -5,7 +5,6 @@ namespace App\ApiResource;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata\ApiFilter;
-use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
@@ -25,11 +24,8 @@ use Symfony\Component\Validator\Constraints as Assert;
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: Course::class),
 )]
-class CourseApi
+class CourseApi extends BaseEntityApi
 {
-    #[ApiProperty(readable: false, writable: false, identifier: true)]
-    public ?int $id = null;
-
     #[Assert\NotBlank]
     #[ApiFilter(SearchFilter::class, strategy: 'ipartial')]
     #[Groups(['course:get', 'program:get', 'module:get', 'search', 'user', 'document:get', 'user:document_views'])]

--- a/backend/src/ApiResource/CourseApi.php
+++ b/backend/src/ApiResource/CourseApi.php
@@ -31,13 +31,13 @@ class CourseApi extends BaseEntityApi
     #[ApiFilter(SearchFilter::class, strategy: 'ipartial')]
     #[Groups(
         [
-        SerializationGroups::COURSE_GET,
-        SerializationGroups::PROGRAM_GET,
-        SerializationGroups::MODULE_GET,
-        SerializationGroups::SEARCH,
-        SerializationGroups::USER,
-        SerializationGroups::DOCUMENT_GET,
-        SerializationGroups::USER_DOCUMENT_VIEWS
+            SerializationGroups::COURSE_GET,
+            SerializationGroups::PROGRAM_GET,
+            SerializationGroups::MODULE_GET,
+            SerializationGroups::SEARCH,
+            SerializationGroups::USER,
+            SerializationGroups::DOCUMENT_GET,
+            SerializationGroups::USER_DOCUMENT_VIEWS
         ]
     )]
     public ?string $name = null;
@@ -47,12 +47,12 @@ class CourseApi extends BaseEntityApi
     #[ApiFilter(SearchFilter::class, strategy: 'ipartial')]
     #[Groups(
         [
-        SerializationGroups::COURSE_GET,
-        SerializationGroups::PROGRAM_GET,
-        SerializationGroups::MODULE_GET,
-        SerializationGroups::SEARCH,
-        SerializationGroups::USER,
-        SerializationGroups::DOCUMENT_GET
+            SerializationGroups::COURSE_GET,
+            SerializationGroups::PROGRAM_GET,
+            SerializationGroups::MODULE_GET,
+            SerializationGroups::SEARCH,
+            SerializationGroups::USER,
+            SerializationGroups::DOCUMENT_GET
         ]
     )]
     public ?string $code = null;
@@ -64,20 +64,20 @@ class CourseApi extends BaseEntityApi
 
     #[Groups(
         [
-        SerializationGroups::COURSE_GET,
-        SerializationGroups::PROGRAM_GET,
-        SerializationGroups::MODULE_GET,
-        SerializationGroups::SEARCH
+            SerializationGroups::COURSE_GET,
+            SerializationGroups::PROGRAM_GET,
+            SerializationGroups::MODULE_GET,
+            SerializationGroups::SEARCH
         ]
     )]
     public array $professors = [];
 
     #[Groups(
         [
-        SerializationGroups::COURSE_GET,
-        SerializationGroups::PROGRAM_GET,
-        SerializationGroups::MODULE_GET,
-        SerializationGroups::SEARCH
+            SerializationGroups::COURSE_GET,
+            SerializationGroups::PROGRAM_GET,
+            SerializationGroups::MODULE_GET,
+            SerializationGroups::SEARCH
         ]
     )]
     public array $semesters = [];
@@ -85,10 +85,10 @@ class CourseApi extends BaseEntityApi
     #[Assert\Positive]
     #[Groups(
         [
-        SerializationGroups::COURSE_GET,
-        SerializationGroups::PROGRAM_GET,
-        SerializationGroups::MODULE_GET,
-        SerializationGroups::SEARCH
+            SerializationGroups::COURSE_GET,
+            SerializationGroups::PROGRAM_GET,
+            SerializationGroups::MODULE_GET,
+            SerializationGroups::SEARCH
         ]
     )]
     public ?int $credits = null;

--- a/backend/src/ApiResource/CourseApi.php
+++ b/backend/src/ApiResource/CourseApi.php
@@ -8,6 +8,7 @@ use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use App\Constants\SerializationGroups;
 use App\Entity\Course;
 use App\State\EntityClassDtoStateProcessor;
 use App\State\EntityClassDtoStateProvider;
@@ -17,8 +18,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ApiResource(
     shortName: 'Course',
     operations: [
-        new Get(normalizationContext: ['groups' => ['course:get']]),
-        new GetCollection(),
+        new Get(normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::COURSE_GET]]),
+        new GetCollection(normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::COURSE_GET]]),
     ],
     provider: EntityClassDtoStateProvider::class,
     processor: EntityClassDtoStateProcessor::class,
@@ -28,57 +29,97 @@ class CourseApi extends BaseEntityApi
 {
     #[Assert\NotBlank]
     #[ApiFilter(SearchFilter::class, strategy: 'ipartial')]
-    #[Groups(['course:get', 'program:get', 'module:get', 'search', 'user', 'document:get', 'user:document_views'])]
+    #[Groups(
+        [
+        SerializationGroups::COURSE_GET,
+        SerializationGroups::PROGRAM_GET,
+        SerializationGroups::MODULE_GET,
+        SerializationGroups::SEARCH,
+        SerializationGroups::USER,
+        SerializationGroups::DOCUMENT_GET,
+        SerializationGroups::USER_DOCUMENT_VIEWS
+        ]
+    )]
     public ?string $name = null;
 
     #[Assert\NotBlank]
     #[Assert\Length(6)]
     #[ApiFilter(SearchFilter::class, strategy: 'ipartial')]
-    #[Groups(['course:get', 'program:get', 'module:get', 'search', 'user', 'document:get'])]
+    #[Groups(
+        [
+        SerializationGroups::COURSE_GET,
+        SerializationGroups::PROGRAM_GET,
+        SerializationGroups::MODULE_GET,
+        SerializationGroups::SEARCH,
+        SerializationGroups::USER,
+        SerializationGroups::DOCUMENT_GET
+        ]
+    )]
     public ?string $code = null;
 
     #[Assert\NotBlank]
     #[Assert\Choice(choices: ['nl', 'en'], message: 'Choose a valid language.')]
-    #[Groups(['course:get'])]
+    #[Groups([SerializationGroups::COURSE_GET])]
     public ?string $language = null;
 
-    #[Groups(['course:get', 'program:get', 'module:get', 'search'])]
+    #[Groups(
+        [
+        SerializationGroups::COURSE_GET,
+        SerializationGroups::PROGRAM_GET,
+        SerializationGroups::MODULE_GET,
+        SerializationGroups::SEARCH
+        ]
+    )]
     public array $professors = [];
 
-    #[Groups(['course:get', 'program:get', 'module:get', 'search'])]
+    #[Groups(
+        [
+        SerializationGroups::COURSE_GET,
+        SerializationGroups::PROGRAM_GET,
+        SerializationGroups::MODULE_GET,
+        SerializationGroups::SEARCH
+        ]
+    )]
     public array $semesters = [];
 
     #[Assert\Positive]
-    #[Groups(['course:get', 'program:get', 'module:get', 'search'])]
+    #[Groups(
+        [
+        SerializationGroups::COURSE_GET,
+        SerializationGroups::PROGRAM_GET,
+        SerializationGroups::MODULE_GET,
+        SerializationGroups::SEARCH
+        ]
+    )]
     public ?int $credits = null;
 
     /**
      * @var CourseApi[]
      */
-    #[Groups(['course:get'])]
+    #[Groups([SerializationGroups::COURSE_GET])]
     public array $identicalCourses = [];
 
     /**
      * @var CourseApi[]
      */
-    #[Groups(['course:get'])]
+    #[Groups([SerializationGroups::COURSE_GET])]
     public array $oldCourses = [];
 
     /**
      * @var CourseApi[]
      */
-    #[Groups(['course:get'])]
+    #[Groups([SerializationGroups::COURSE_GET])]
     public array $newCourses = [];
 
     /**
      * @var ModuleApi[]
      */
-    #[Groups(['course:get'])]
+    #[Groups([SerializationGroups::COURSE_GET])]
     public array $modules = [];
 
     /**
      * @var CourseCommentApi[]
      */
-    #[Groups(['course:get'])]
+    #[Groups([SerializationGroups::COURSE_GET])]
     public array $courseComments = [];
 }

--- a/backend/src/ApiResource/CourseCommentApi.php
+++ b/backend/src/ApiResource/CourseCommentApi.php
@@ -3,7 +3,6 @@
 namespace App\ApiResource;
 
 use ApiPlatform\Doctrine\Orm\State\Options;
-use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
@@ -21,14 +20,14 @@ use Symfony\Component\Serializer\Attribute\Groups;
         new Get(),
         new GetCollection(),
         new Patch(
-        // This redirects the security check to all voters to see if one accepts CourseCommentApi objects
-        // This is handled by the src/Security/Voter/AbstractCommentVoter
+            // This redirects the security check to all voters to see if one accepts CourseCommentApi objects
+            // This is handled by the src/Security/Voter/AbstractCommentVoter
             security: 'is_granted("EDIT", object)'
         ),
         new Post(),
         new Delete(
-        // This redirects the security check to all voters to see if one accepts CourseCommentApi objects
-        // This is handled by the src/Security/Voter/AbstractCommentVoter
+            // This redirects the security check to all voters to see if one accepts CourseCommentApi objects
+            // This is handled by the src/Security/Voter/AbstractCommentVoter
             security: 'is_granted("DELETE", object)'
         ),
     ],
@@ -38,9 +37,6 @@ use Symfony\Component\Serializer\Attribute\Groups;
 )]
 class CourseCommentApi extends AbstractCommentApi
 {
-    #[ApiProperty(readable: false, writable: false, identifier: true)]
-    public ?int $id = null;
-
     #[Groups(['course:get'])]
     public ?CourseApi $course;
 

--- a/backend/src/ApiResource/CourseCommentApi.php
+++ b/backend/src/ApiResource/CourseCommentApi.php
@@ -9,6 +9,7 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
+use App\Constants\SerializationGroups;
 use App\Entity\CourseComment;
 use App\State\EntityClassDtoStateProcessor;
 use App\State\EntityClassDtoStateProvider;
@@ -31,15 +32,16 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: 'is_granted("DELETE", object)'
         ),
     ],
+    normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::COURSE_COMMENT_GET]],
     provider: EntityClassDtoStateProvider::class,
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: CourseComment::class),
 )]
 class CourseCommentApi extends AbstractCommentApi
 {
-    #[Groups(['course:get'])]
+    #[Groups([SerializationGroups::COURSE_COMMENT_GET, SerializationGroups::COURSE_GET])]
     public ?CourseApi $course;
 
-    #[Groups(['course:get'])]
+    #[Groups([SerializationGroups::COURSE_COMMENT_GET, SerializationGroups::COURSE_GET])]
     public ?CommentCategoryApi $category;
 }

--- a/backend/src/ApiResource/CourseCommentVoteApi.php
+++ b/backend/src/ApiResource/CourseCommentVoteApi.php
@@ -9,6 +9,7 @@ use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
+use App\Constants\SerializationGroups;
 use App\Controller\Api\CreateVoteController;
 use App\Controller\Api\DeleteVoteController;
 use App\Entity\CourseCommentVote;
@@ -60,8 +61,8 @@ use Symfony\Component\Serializer\Attribute\Groups;
             )
         ),
     ],
-    normalizationContext: ['groups' => ['vote:read']],
-    denormalizationContext: ['groups' => ['vote:write']],
+    normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::VOTE_READ]],
+    denormalizationContext: ['groups' => [SerializationGroups::VOTE_WRITE]],
     provider: EntityClassDtoStateProvider::class,
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: CourseCommentVote::class),
@@ -69,6 +70,6 @@ use Symfony\Component\Serializer\Attribute\Groups;
 class CourseCommentVoteApi extends AbstractVoteApi
 {
     #[ApiProperty(writable: false)]
-    #[Groups(['vote:read'])]
+    #[Groups([SerializationGroups::VOTE_READ])]
     public ?CourseCommentApi $courseComment = null;
 }

--- a/backend/src/ApiResource/DocumentApi.php
+++ b/backend/src/ApiResource/DocumentApi.php
@@ -132,11 +132,11 @@ class DocumentApi extends NodeApi
     #[ApiFilter(SearchFilter::class, strategy: 'ipartial')]
     #[Groups(
         [
-        SerializationGroups::SEARCH,
-        SerializationGroups::USER,
-        SerializationGroups::DOCUMENT_GET,
-        SerializationGroups::DOCUMENT_CREATE,
-        SerializationGroups::USER_DOCUMENT_VIEWS
+            SerializationGroups::SEARCH,
+            SerializationGroups::USER,
+            SerializationGroups::DOCUMENT_GET,
+            SerializationGroups::DOCUMENT_CREATE,
+            SerializationGroups::USER_DOCUMENT_VIEWS
         ]
     )]
     public ?string $name = null;
@@ -144,11 +144,11 @@ class DocumentApi extends NodeApi
     #[ApiFilter(SearchFilter::class, strategy: 'exact')]
     #[Groups(
         [
-        SerializationGroups::SEARCH,
-        SerializationGroups::USER,
-        SerializationGroups::DOCUMENT_GET,
-        SerializationGroups::DOCUMENT_CREATE,
-        SerializationGroups::USER_DOCUMENT_VIEWS
+            SerializationGroups::SEARCH,
+            SerializationGroups::USER,
+            SerializationGroups::DOCUMENT_GET,
+            SerializationGroups::DOCUMENT_CREATE,
+            SerializationGroups::USER_DOCUMENT_VIEWS
         ]
     )]
     public ?CourseApi $course;
@@ -156,10 +156,10 @@ class DocumentApi extends NodeApi
     #[ApiFilter(SearchFilter::class, strategy: 'exact')]
     #[Groups(
         [
-        SerializationGroups::SEARCH,
-        SerializationGroups::USER,
-        SerializationGroups::DOCUMENT_GET,
-        SerializationGroups::DOCUMENT_CREATE
+            SerializationGroups::SEARCH,
+            SerializationGroups::USER,
+            SerializationGroups::DOCUMENT_GET,
+            SerializationGroups::DOCUMENT_CREATE
         ]
     )]
     public ?DocumentCategoryApi $category = null;
@@ -212,10 +212,10 @@ class DocumentApi extends NodeApi
     #[ApiFilter(TagFilter::class, properties: ['tags' => true, 'tags.name' => true])]
     #[Groups(
         [
-        SerializationGroups::SEARCH,
-        SerializationGroups::USER,
-        SerializationGroups::DOCUMENT_GET,
-        SerializationGroups::DOCUMENT_CREATE
+            SerializationGroups::SEARCH,
+            SerializationGroups::USER,
+            SerializationGroups::DOCUMENT_GET,
+            SerializationGroups::DOCUMENT_CREATE
         ]
     )]
     public array $tags = [];

--- a/backend/src/ApiResource/DocumentApi.php
+++ b/backend/src/ApiResource/DocumentApi.php
@@ -124,11 +124,8 @@ use Symfony\Component\Validator\Constraints as Assert;
     stateOptions: new Options(entityClass: Document::class)
 )]
 #[ApiFilter(OrderFilter::class)]
-class DocumentApi
+class DocumentApi extends NodeApi
 {
-    #[ApiProperty(readable: false, writable: false, identifier: true)]
-    public ?int $id = null;
-
     #[Assert\NotBlank]
     #[ApiFilter(SearchFilter::class, strategy: 'ipartial')]
     #[Groups(['search', 'user', 'document:get', 'document:create', 'user:document_views'])]
@@ -183,14 +180,6 @@ class DocumentApi
     )]
     #[Groups(['search', 'document:get'])]
     public ?UserApi $creator;
-
-    #[ApiProperty(writable: false)]
-    #[Groups(['search', 'document:get'])]
-    public string $createdAt;
-
-    #[ApiProperty(writable: false)]
-    #[Groups(['search', 'document:get'])]
-    public string $updatedAt;
 
     /**
      * @var TagApi[]

--- a/backend/src/ApiResource/DocumentApi.php
+++ b/backend/src/ApiResource/DocumentApi.php
@@ -13,6 +13,7 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model;
+use App\Constants\SerializationGroups;
 use App\Controller\Api\CreateDocumentController;
 use App\Entity\Document;
 use App\Filter\TagFilter;
@@ -28,7 +29,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     shortName: 'Document',
     operations: [
         new Get(
-            normalizationContext: ['groups' => ['document:get']],
+            normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::DOCUMENT_GET]],
             provider: DocumentApiProvider::class
         ),
         new GetCollection(
@@ -50,7 +51,7 @@ use Symfony\Component\Validator\Constraints as Assert;
                     )
                 ]
             ),
-            normalizationContext: ['groups' => ['document:get']],
+            normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::DOCUMENT_GET]],
             provider: DocumentApiProvider::class
         ),
         new Post(
@@ -112,7 +113,8 @@ use Symfony\Component\Validator\Constraints as Assert;
                     )
                 )
             ),
-            validationContext: ['groups' => ['document:create']],
+            validationContext: ['groups' => [SerializationGroups::DOCUMENT_CREATE]],
+            normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::DOCUMENT_CREATE]],
             read: false,
             deserialize: false,
             validate: false,
@@ -128,47 +130,70 @@ class DocumentApi extends NodeApi
 {
     #[Assert\NotBlank]
     #[ApiFilter(SearchFilter::class, strategy: 'ipartial')]
-    #[Groups(['search', 'user', 'document:get', 'document:create', 'user:document_views'])]
+    #[Groups(
+        [
+        SerializationGroups::SEARCH,
+        SerializationGroups::USER,
+        SerializationGroups::DOCUMENT_GET,
+        SerializationGroups::DOCUMENT_CREATE,
+        SerializationGroups::USER_DOCUMENT_VIEWS
+        ]
+    )]
     public ?string $name = null;
 
     #[ApiFilter(SearchFilter::class, strategy: 'exact')]
-    #[Groups(['search', 'user', 'document:get', 'document:create', 'user:document_views'])]
+    #[Groups(
+        [
+        SerializationGroups::SEARCH,
+        SerializationGroups::USER,
+        SerializationGroups::DOCUMENT_GET,
+        SerializationGroups::DOCUMENT_CREATE,
+        SerializationGroups::USER_DOCUMENT_VIEWS
+        ]
+    )]
     public ?CourseApi $course;
 
     #[ApiFilter(SearchFilter::class, strategy: 'exact')]
-    #[Groups(['search', 'user', 'document:get', 'document:create'])]
+    #[Groups(
+        [
+        SerializationGroups::SEARCH,
+        SerializationGroups::USER,
+        SerializationGroups::DOCUMENT_GET,
+        SerializationGroups::DOCUMENT_CREATE
+        ]
+    )]
     public ?DocumentCategoryApi $category = null;
 
     #[Assert\Length(5)]
     #[ApiFilter(SearchFilter::class, strategy: 'ipartial')]
-    #[Groups(['document:get', 'document:create'])]
+    #[Groups([SerializationGroups::DOCUMENT_GET, SerializationGroups::DOCUMENT_CREATE])]
     public ?string $year = null;
 
     #[ApiProperty(writable: false)]
     #[ApiFilter(BooleanFilter::class)]
-    #[Groups(['search', 'document:get'])]
+    #[Groups([SerializationGroups::SEARCH, SerializationGroups::DOCUMENT_GET])]
     public bool $under_review = true;
 
     #[ApiFilter(BooleanFilter::class)]
-    #[Groups(['document:get'])]
+    #[Groups([SerializationGroups::DOCUMENT_GET])]
     public bool $anonymous = false;
 
-    #[Groups(['document:get'])]
+    #[Groups([SerializationGroups::DOCUMENT_GET])]
     public ?string $contentUrl = null;
 
     #[ApiProperty(writable: false)]
-    #[Groups(['document:get'])]
+    #[Groups([SerializationGroups::DOCUMENT_GET])]
     public ?string $mimetype = null;
 
     #[ApiProperty(writable: false)]
-    #[Groups(['document:get'])]
+    #[Groups([SerializationGroups::DOCUMENT_GET])]
     public ?string $filename = null;
 
     #[ApiProperty(writable: false)]
-    #[Groups(['document:get'])]
+    #[Groups([SerializationGroups::DOCUMENT_GET])]
     public ?int $fileSize = null;
 
-    #[Assert\NotNull(groups: ['document:create'])]
+    #[Assert\NotNull(groups: [SerializationGroups::DOCUMENT_CREATE])]
     #[ApiProperty(readable: false)]
     public ?File $file = null;
 
@@ -178,13 +203,20 @@ class DocumentApi extends NodeApi
         strategy: 'exact',
         properties: ['creator' => 'exact', 'creator.fullName' => 'ipartial']
     )]
-    #[Groups(['search', 'document:get'])]
+    #[Groups([SerializationGroups::SEARCH, SerializationGroups::DOCUMENT_GET])]
     public ?UserApi $creator;
 
     /**
      * @var TagApi[]
      */
     #[ApiFilter(TagFilter::class, properties: ['tags' => true, 'tags.name' => true])]
-    #[Groups(['search', 'user', 'document:get', 'document:create'])]
+    #[Groups(
+        [
+        SerializationGroups::SEARCH,
+        SerializationGroups::USER,
+        SerializationGroups::DOCUMENT_GET,
+        SerializationGroups::DOCUMENT_CREATE
+        ]
+    )]
     public array $tags = [];
 }

--- a/backend/src/ApiResource/DocumentCategoryApi.php
+++ b/backend/src/ApiResource/DocumentCategoryApi.php
@@ -4,10 +4,10 @@ namespace App\ApiResource;
 
 use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata\ApiFilter;
-use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use App\Constants\SerializationGroups;
 use App\Entity\DocumentCategory;
 use App\Filter\MultiLangSearchFilter;
 use App\State\EntityClassDtoStateProcessor;
@@ -21,6 +21,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Get(),
         new GetCollection(),
     ],
+    normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::DOCUMENT_CATEGORY_GET]],
     provider: EntityClassDtoStateProvider::class,
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: DocumentCategory::class),
@@ -31,9 +32,12 @@ class DocumentCategoryApi extends BaseEntityApi
     #[ApiFilter(
         MultiLangSearchFilter::class,
         properties: [
-        'name' => ['name_nl',
-        'name_en']]
+            'name' => [
+                'name_nl',
+                'name_en'
+            ]
+        ]
     )]
-    #[Groups(['document:get'])]
+    #[Groups([SerializationGroups::DOCUMENT_CATEGORY_GET, SerializationGroups::DOCUMENT_GET])]
     public ?string $name = null;
 }

--- a/backend/src/ApiResource/DocumentCategoryApi.php
+++ b/backend/src/ApiResource/DocumentCategoryApi.php
@@ -25,11 +25,8 @@ use Symfony\Component\Validator\Constraints as Assert;
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: DocumentCategory::class),
 )]
-class DocumentCategoryApi
+class DocumentCategoryApi extends BaseEntityApi
 {
-    #[ApiProperty(readable: false, writable: false, identifier: true)]
-    public ?int $id = null;
-
     #[Assert\NotBlank]
     #[ApiFilter(
         MultiLangSearchFilter::class,

--- a/backend/src/ApiResource/DocumentCommentApi.php
+++ b/backend/src/ApiResource/DocumentCommentApi.php
@@ -11,6 +11,7 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
+use App\Constants\SerializationGroups;
 use App\Entity\DocumentComment;
 use App\State\EntityClassDtoStateProcessor;
 use App\State\EntityClassDtoStateProvider;
@@ -19,24 +20,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
 #[ApiResource(
     shortName: 'DocumentComment',
     operations: [
-        new Get(
-            normalizationContext: ['groups' => ['document_comment:get']]
-        ),
-        new GetCollection(
-            normalizationContext: ['groups' => ['document_comment:get']]
-        ),
+        new Get(),
+        new GetCollection(),
         new Patch(
             // This redirects the security check to all voters to see if one accepts CourseCommentApi objects
             // This is handled by the src/Security/Voter/AbstractCommentVoter
             security: 'is_granted("EDIT", object)'
         ),
-        new Post(normalizationContext: ['groups' => ['document_comment:get']]),
+        new Post(),
         new Delete(
             // This redirects the security check to all voters to see if one accepts CourseCommentApi objects
             // This is handled by the src/Security/Voter/AbstractCommentVoter
             security: 'is_granted("DELETE", object)'
         ),
     ],
+    normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::DOCUMENT_COMMENT_GET]],
     provider: EntityClassDtoStateProvider::class,
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: DocumentComment::class),
@@ -44,6 +42,6 @@ use Symfony\Component\Serializer\Attribute\Groups;
 class DocumentCommentApi extends AbstractCommentApi
 {
     #[ApiFilter(SearchFilter::class, strategy: 'exact')]
-    #[Groups(['document_comment:get'])]
+    #[Groups([SerializationGroups::DOCUMENT_COMMENT_GET])]
     public ?DocumentApi $document;
 }

--- a/backend/src/ApiResource/DocumentCommentApi.php
+++ b/backend/src/ApiResource/DocumentCommentApi.php
@@ -5,7 +5,6 @@ namespace App\ApiResource;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata\ApiFilter;
-use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
@@ -27,14 +26,14 @@ use Symfony\Component\Serializer\Attribute\Groups;
             normalizationContext: ['groups' => ['document_comment:get']]
         ),
         new Patch(
-        // This redirects the security check to all voters to see if one accepts CourseCommentApi objects
-        // This is handled by the src/Security/Voter/AbstractCommentVoter
+            // This redirects the security check to all voters to see if one accepts CourseCommentApi objects
+            // This is handled by the src/Security/Voter/AbstractCommentVoter
             security: 'is_granted("EDIT", object)'
         ),
         new Post(normalizationContext: ['groups' => ['document_comment:get']]),
         new Delete(
-        // This redirects the security check to all voters to see if one accepts CourseCommentApi objects
-        // This is handled by the src/Security/Voter/AbstractCommentVoter
+            // This redirects the security check to all voters to see if one accepts CourseCommentApi objects
+            // This is handled by the src/Security/Voter/AbstractCommentVoter
             security: 'is_granted("DELETE", object)'
         ),
     ],
@@ -44,9 +43,6 @@ use Symfony\Component\Serializer\Attribute\Groups;
 )]
 class DocumentCommentApi extends AbstractCommentApi
 {
-    #[ApiProperty(readable: false, writable: false, identifier: true)]
-    public ?int $id = null;
-
     #[ApiFilter(SearchFilter::class, strategy: 'exact')]
     #[Groups(['document_comment:get'])]
     public ?DocumentApi $document;

--- a/backend/src/ApiResource/DocumentCommentVoteApi.php
+++ b/backend/src/ApiResource/DocumentCommentVoteApi.php
@@ -9,6 +9,7 @@ use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
+use App\Constants\SerializationGroups;
 use App\Controller\Api\CreateVoteController;
 use App\Controller\Api\DeleteVoteController;
 use App\Entity\DocumentCommentVote;
@@ -60,8 +61,8 @@ use Symfony\Component\Serializer\Attribute\Groups;
             )
         ),
     ],
-    normalizationContext: ['groups' => ['vote:read']],
-    denormalizationContext: ['groups' => ['vote:write']],
+    normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::VOTE_READ]],
+    denormalizationContext: ['groups' => [SerializationGroups::VOTE_WRITE]],
     provider: EntityClassDtoStateProvider::class,
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: DocumentCommentVote::class),
@@ -69,6 +70,6 @@ use Symfony\Component\Serializer\Attribute\Groups;
 class DocumentCommentVoteApi extends AbstractVoteApi
 {
     #[ApiProperty(writable: false)]
-    #[Groups(['vote:read'])]
+    #[Groups([SerializationGroups::VOTE_READ])]
     public ?DocumentCommentApi $documentComment = null;
 }

--- a/backend/src/ApiResource/DocumentVoteApi.php
+++ b/backend/src/ApiResource/DocumentVoteApi.php
@@ -9,6 +9,7 @@ use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
+use App\Constants\SerializationGroups;
 use App\Controller\Api\CreateVoteController;
 use App\Controller\Api\DeleteVoteController;
 use App\Entity\DocumentVote;
@@ -60,8 +61,8 @@ use Symfony\Component\Serializer\Attribute\Groups;
             )
         ),
     ],
-    normalizationContext: ['groups' => ['vote:read']],
-    denormalizationContext: ['groups' => ['vote:write']],
+    normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::VOTE_READ]],
+    denormalizationContext: ['groups' => [SerializationGroups::VOTE_WRITE]],
     provider: EntityClassDtoStateProvider::class,
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: DocumentVote::class),
@@ -69,6 +70,6 @@ use Symfony\Component\Serializer\Attribute\Groups;
 class DocumentVoteApi extends AbstractVoteApi
 {
     #[ApiProperty(writable: false)]
-    #[Groups(['vote:read'])]
+    #[Groups([SerializationGroups::VOTE_READ])]
     public ?DocumentApi $document = null;
 }

--- a/backend/src/ApiResource/HealthcheckApi.php
+++ b/backend/src/ApiResource/HealthcheckApi.php
@@ -6,8 +6,8 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Response;
-use ArrayObject;
 use App\Controller\Api\HealthcheckController;
+use ArrayObject;
 
 #[ApiResource(
     shortName: 'Healthcheck',
@@ -24,14 +24,14 @@ use App\Controller\Api\HealthcheckController;
                         description: 'Service is healthy',
                         content: new ArrayObject(
                             [
-                            'application/json' => [
-                                'example' => [
-                                    'status' => 'ok',
-                                    'timestamp' => '2025-11-08T12:00:00+00:00',
-                                    'service' => 'burgieclan-api',
-                                    'database' => 'connected'
+                                'application/json' => [
+                                    'example' => [
+                                        'status' => 'ok',
+                                        'timestamp' => '2025-11-08T12:00:00+00:00',
+                                        'service' => 'burgieclan-api',
+                                        'database' => 'connected'
+                                    ]
                                 ]
-                            ]
                             ]
                         )
                     ),
@@ -39,15 +39,15 @@ use App\Controller\Api\HealthcheckController;
                         description: 'Service is unhealthy',
                         content: new ArrayObject(
                             [
-                            'application/json' => [
-                                'example' => [
-                                    'status' => 'error',
-                                    'timestamp' => '2025-11-08T12:00:00+00:00',
-                                    'service' => 'burgieclan-api',
-                                    'database' => 'disconnected',
-                                    'error' => 'Database connection failed'
+                                'application/json' => [
+                                    'example' => [
+                                        'status' => 'error',
+                                        'timestamp' => '2025-11-08T12:00:00+00:00',
+                                        'service' => 'burgieclan-api',
+                                        'database' => 'disconnected',
+                                        'error' => 'Database connection failed'
+                                    ]
                                 ]
-                            ]
                             ]
                         )
                     )

--- a/backend/src/ApiResource/ListUserDocumentViewApi.php
+++ b/backend/src/ApiResource/ListUserDocumentViewApi.php
@@ -2,11 +2,10 @@
 
 namespace App\ApiResource;
 
-use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use App\Constants\SerializationGroups;
 use App\Controller\Api\AddDocumentViewToUserController;
-use App\Entity\UserDocumentView;
 use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ApiResource(
@@ -15,7 +14,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
         new Post(
             uriTemplate: 'document_views/batch',
             controller: AddDocumentViewToUserController::class,
-            denormalizationContext: ['groups' => ['user:document_views:batch']],
+            denormalizationContext: ['groups' => [SerializationGroups::USER_DOCUMENT_VIEWS_BATCH]],
         ),
     ],
 )]
@@ -24,6 +23,6 @@ class ListUserDocumentViewApi
     /**
      * @var UserDocumentViewApi[]
      */
-    #[Groups('user:document_views:batch')]
+    #[Groups([SerializationGroups::USER_DOCUMENT_VIEWS_BATCH])]
     public array $userDocumentViews = [];
 }

--- a/backend/src/ApiResource/LitusOAuthCallbackApi.php
+++ b/backend/src/ApiResource/LitusOAuthCallbackApi.php
@@ -22,13 +22,13 @@ use App\Controller\Api\LitusOAuthCallbackController;
                         content: null,
                         headers: new \ArrayObject(
                             [
-                            'Location' => [
-                                'description' => 'Frontend callback URL with JWT tokens and redirect parameters',
-                                'schema' => [
-                                    'type' => 'string',
-                                    'example' => 'http://localhost:3000/auth/callback?token=jwt&refresh_token=refresh'
+                                'Location' => [
+                                    'description' => 'Frontend callback URL with JWT tokens and redirect parameters',
+                                    'schema' => [
+                                        'type' => 'string',
+                                        'example' => 'http://localhost:3000/auth/callback?token=jwt&refresh_token=refresh'
+                                    ]
                                 ]
-                            ]
                             ]
                         )
                     ),
@@ -37,13 +37,13 @@ use App\Controller\Api\LitusOAuthCallbackController;
                         content: null,
                         headers: new \ArrayObject(
                             [
-                            'Location' => [
-                                'description' => 'Frontend callback URL with error parameter',
-                                'schema' => [
-                                    'type' => 'string',
-                                    'example' => 'http://localhost:3000/auth/callback?error=Invalid%20OAuth%20state'
+                                'Location' => [
+                                    'description' => 'Frontend callback URL with error parameter',
+                                    'schema' => [
+                                        'type' => 'string',
+                                        'example' => 'http://localhost:3000/auth/callback?error=Invalid%20OAuth%20state'
+                                    ]
                                 ]
-                            ]
                             ]
                         )
                     )

--- a/backend/src/ApiResource/LitusOAuthInitiateApi.php
+++ b/backend/src/ApiResource/LitusOAuthInitiateApi.php
@@ -22,12 +22,12 @@ use App\Controller\Api\LitusOAuthInitiateController;
                         content: null,
                         headers: new \ArrayObject(
                             [
-                            'Location' => [
-                                'description' => 'OAuth provider authorization URL',
-                                'schema' => [
-                                    'type' => 'string'
+                                'Location' => [
+                                    'description' => 'OAuth provider authorization URL',
+                                    'schema' => [
+                                        'type' => 'string'
+                                    ]
                                 ]
-                            ]
                             ]
                         )
                     )

--- a/backend/src/ApiResource/LogoutApi.php
+++ b/backend/src/ApiResource/LogoutApi.php
@@ -33,17 +33,17 @@ use ArrayObject;
                 requestBody: new RequestBody(
                     content: new ArrayObject(
                         [
-                        'application/json' => [
-                            'schema' => [
-                                'type' => 'object',
-                                'properties' => [
-                                    'refresh_token' => [
-                                        'type' => 'string',
-                                        'description' => 'The refresh token to invalidate'
+                            'application/json' => [
+                                'schema' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'refresh_token' => [
+                                            'type' => 'string',
+                                            'description' => 'The refresh token to invalidate'
+                                        ]
                                     ]
                                 ]
                             ]
-                        ]
                         ]
                     )
                 )

--- a/backend/src/ApiResource/ModuleApi.php
+++ b/backend/src/ApiResource/ModuleApi.php
@@ -8,6 +8,7 @@ use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use App\Constants\SerializationGroups;
 use App\Entity\Module;
 use App\State\EntityClassDtoStateProcessor;
 use App\State\EntityClassDtoStateProvider;
@@ -17,9 +18,10 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ApiResource(
     shortName: 'Module',
     operations: [
-        new Get(normalizationContext: ['groups' => ['module:get']]),
+        new Get(),
         new GetCollection(),
     ],
+    normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::MODULE_GET]],
     provider: EntityClassDtoStateProvider::class,
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: Module::class),
@@ -28,21 +30,34 @@ class ModuleApi extends BaseEntityApi
 {
     #[Assert\NotBlank]
     #[ApiFilter(SearchFilter::class, strategy: 'ipartial')]
-    #[Groups(['module:get', 'program:get', 'search', 'user'])]
+    #[Groups(
+        [
+        SerializationGroups::MODULE_GET,
+        SerializationGroups::PROGRAM_GET,
+        SerializationGroups::SEARCH,
+        SerializationGroups::USER
+        ]
+    )]
     public ?string $name = null;
 
     /**
      * @var CourseApi[]
      */
-    #[Groups(['module:get', 'program:get'])]
+    #[Groups([SerializationGroups::MODULE_GET, SerializationGroups::PROGRAM_GET])]
     public array $courses;
 
     /**
      * @var ModuleApi[]
      */
-    #[Groups(['module:get', 'program:get'])]
+    #[Groups([SerializationGroups::MODULE_GET, SerializationGroups::PROGRAM_GET])]
     public array $modules;
 
-    #[Groups(['module:get', 'program:get', 'search'])]
+    #[Groups(
+        [
+        SerializationGroups::MODULE_GET,
+        SerializationGroups::PROGRAM_GET,
+        SerializationGroups::SEARCH,
+        ]
+    )]
     public ProgramApi $program;
 }

--- a/backend/src/ApiResource/ModuleApi.php
+++ b/backend/src/ApiResource/ModuleApi.php
@@ -32,10 +32,10 @@ class ModuleApi extends BaseEntityApi
     #[ApiFilter(SearchFilter::class, strategy: 'ipartial')]
     #[Groups(
         [
-        SerializationGroups::MODULE_GET,
-        SerializationGroups::PROGRAM_GET,
-        SerializationGroups::SEARCH,
-        SerializationGroups::USER
+            SerializationGroups::MODULE_GET,
+            SerializationGroups::PROGRAM_GET,
+            SerializationGroups::SEARCH,
+            SerializationGroups::USER
         ]
     )]
     public ?string $name = null;
@@ -54,9 +54,9 @@ class ModuleApi extends BaseEntityApi
 
     #[Groups(
         [
-        SerializationGroups::MODULE_GET,
-        SerializationGroups::PROGRAM_GET,
-        SerializationGroups::SEARCH,
+            SerializationGroups::MODULE_GET,
+            SerializationGroups::PROGRAM_GET,
+            SerializationGroups::SEARCH,
         ]
     )]
     public ProgramApi $program;

--- a/backend/src/ApiResource/ModuleApi.php
+++ b/backend/src/ApiResource/ModuleApi.php
@@ -5,7 +5,6 @@ namespace App\ApiResource;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata\ApiFilter;
-use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
@@ -25,11 +24,8 @@ use Symfony\Component\Validator\Constraints as Assert;
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: Module::class),
 )]
-class ModuleApi
+class ModuleApi extends BaseEntityApi
 {
-    #[ApiProperty(readable: false, writable: false, identifier: true)]
-    public ?int $id = null;
-
     #[Assert\NotBlank]
     #[ApiFilter(SearchFilter::class, strategy: 'ipartial')]
     #[Groups(['module:get', 'program:get', 'search', 'user'])]

--- a/backend/src/ApiResource/NodeApi.php
+++ b/backend/src/ApiResource/NodeApi.php
@@ -7,18 +7,10 @@ use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiProperty;
 use Symfony\Component\Serializer\Attribute\Groups;
 
-abstract class NodeApi
+abstract class NodeApi extends BaseEntityApi
 {
     #[ApiProperty(writable: false)]
     #[ApiFilter(SearchFilter::class, strategy: 'exact')]
     #[Groups(['course:get', 'document_comment:get'])]
     public ?UserApi $creator;
-
-    #[ApiProperty(writable: false)]
-    #[Groups(['course:get', 'document_comment:get'])]
-    public string $createdAt;
-
-    #[ApiProperty(writable: false)]
-    #[Groups(['course:get', 'document_comment:get'])]
-    public string $updatedAt;
 }

--- a/backend/src/ApiResource/NodeApi.php
+++ b/backend/src/ApiResource/NodeApi.php
@@ -5,12 +5,20 @@ namespace App\ApiResource;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiProperty;
+use App\Constants\SerializationGroups;
 use Symfony\Component\Serializer\Attribute\Groups;
 
 abstract class NodeApi extends BaseEntityApi
 {
     #[ApiProperty(writable: false)]
     #[ApiFilter(SearchFilter::class, strategy: 'exact')]
-    #[Groups(['course:get', 'document_comment:get'])]
+    #[Groups(
+        [
+        SerializationGroups::COURSE_GET,
+        SerializationGroups::DOCUMENT_COMMENT_GET,
+        SerializationGroups::COURSE_COMMENT_GET,
+        SerializationGroups::ANNOUNCEMENT_GET
+        ]
+    )]
     public ?UserApi $creator;
 }

--- a/backend/src/ApiResource/NodeApi.php
+++ b/backend/src/ApiResource/NodeApi.php
@@ -14,10 +14,10 @@ abstract class NodeApi extends BaseEntityApi
     #[ApiFilter(SearchFilter::class, strategy: 'exact')]
     #[Groups(
         [
-        SerializationGroups::COURSE_GET,
-        SerializationGroups::DOCUMENT_COMMENT_GET,
-        SerializationGroups::COURSE_COMMENT_GET,
-        SerializationGroups::ANNOUNCEMENT_GET
+            SerializationGroups::COURSE_GET,
+            SerializationGroups::DOCUMENT_COMMENT_GET,
+            SerializationGroups::COURSE_COMMENT_GET,
+            SerializationGroups::ANNOUNCEMENT_GET
         ]
     )]
     public ?UserApi $creator;

--- a/backend/src/ApiResource/PageApi.php
+++ b/backend/src/ApiResource/PageApi.php
@@ -63,7 +63,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: Page::class),
 )]
-class PageApi
+class PageApi extends BaseEntityApi
 {
     #[ApiProperty(readable: true, writable: false, identifier: true)]
     #[Assert\NotBlank]

--- a/backend/src/ApiResource/PageApi.php
+++ b/backend/src/ApiResource/PageApi.php
@@ -9,10 +9,12 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
+use App\Constants\SerializationGroups;
 use App\Entity\Page;
 use App\State\EntityClassDtoStateProcessor;
 use App\State\EntityClassDtoStateProvider;
 use App\State\PageApiProvider;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
@@ -59,23 +61,32 @@ use Symfony\Component\Validator\Constraints as Assert;
             provider: PageApiProvider::class,
         )
     ],
+    normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::PAGE_GET]],
     provider: EntityClassDtoStateProvider::class,
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: Page::class),
 )]
 class PageApi extends BaseEntityApi
 {
+    // Override BaseEntityApi: urlKey is the identifier here, not id
+    #[ApiProperty(readable: false, writable: false, identifier: false)]
+    public ?int $id = null;
+
     #[ApiProperty(readable: true, writable: false, identifier: true)]
     #[Assert\NotBlank]
     #[Assert\Length(max: 255)]
+    #[Groups([SerializationGroups::PAGE_GET])]
     public ?string $urlKey = null;
 
     #[Assert\NotBlank]
     #[Assert\Length(max: 255)]
+    #[Groups([SerializationGroups::PAGE_GET])]
     public ?string $name = null;
 
     #[Assert\NotBlank]
+    #[Groups([SerializationGroups::PAGE_GET])]
     public ?string $content = null;
 
+    #[Groups([SerializationGroups::PAGE_GET])]
     public bool $publicAvailable = false;
 }

--- a/backend/src/ApiResource/ProgramApi.php
+++ b/backend/src/ApiResource/ProgramApi.php
@@ -34,9 +34,9 @@ class ProgramApi extends BaseEntityApi
     #[ApiFilter(SearchFilter::class, strategy: 'ipartial')]
     #[Groups(
         [
-        SerializationGroups::PROGRAM_GET,
-        SerializationGroups::SEARCH,
-        SerializationGroups::USER
+            SerializationGroups::PROGRAM_GET,
+            SerializationGroups::SEARCH,
+            SerializationGroups::USER
         ]
     )]
     public ?string $name = null;

--- a/backend/src/ApiResource/ProgramApi.php
+++ b/backend/src/ApiResource/ProgramApi.php
@@ -6,7 +6,6 @@ use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata\ApiFilter;
-use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
@@ -27,11 +26,8 @@ use Symfony\Component\Validator\Constraints as Assert;
     stateOptions: new Options(entityClass: Program::class),
 )]
 #[ApiFilter(OrderFilter::class)]
-class ProgramApi
+class ProgramApi extends BaseEntityApi
 {
-    #[ApiProperty(readable: false, writable: false, identifier: true)]
-    public ?int $id = null;
-
     #[Assert\NotBlank]
     #[ApiFilter(SearchFilter::class, strategy: 'ipartial')]
     #[Groups(['program:get', 'search', 'user'])]

--- a/backend/src/ApiResource/ProgramApi.php
+++ b/backend/src/ApiResource/ProgramApi.php
@@ -9,6 +9,7 @@ use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use App\Constants\SerializationGroups;
 use App\Entity\Program;
 use App\State\EntityClassDtoStateProcessor;
 use App\State\EntityClassDtoStateProvider;
@@ -19,8 +20,9 @@ use Symfony\Component\Validator\Constraints as Assert;
     shortName: 'Program',
     operations: [
         new Get(),
-        new GetCollection(normalizationContext: ['groups' => ['program:get']]),
+        new GetCollection(),
     ],
+    normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::PROGRAM_GET]],
     provider: EntityClassDtoStateProvider::class,
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: Program::class),
@@ -30,12 +32,18 @@ class ProgramApi extends BaseEntityApi
 {
     #[Assert\NotBlank]
     #[ApiFilter(SearchFilter::class, strategy: 'ipartial')]
-    #[Groups(['program:get', 'search', 'user'])]
+    #[Groups(
+        [
+        SerializationGroups::PROGRAM_GET,
+        SerializationGroups::SEARCH,
+        SerializationGroups::USER
+        ]
+    )]
     public ?string $name = null;
 
     /**
      * @var ModuleApi[]
      */
-    #[Groups(['program:get'])]
+    #[Groups([SerializationGroups::PROGRAM_GET])]
     public array $modules = [];
 }

--- a/backend/src/ApiResource/QuickLinkApi.php
+++ b/backend/src/ApiResource/QuickLinkApi.php
@@ -8,9 +8,11 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
+use App\Constants\SerializationGroups;
 use App\Entity\QuickLink;
 use App\State\EntityClassDtoStateProcessor;
 use App\State\EntityClassDtoStateProvider;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ApiResource(
     shortName: 'QuickLink',
@@ -50,13 +52,16 @@ use App\State\EntityClassDtoStateProvider;
             )
         ),
     ],
+    normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::QUICKLINK_GET]],
     provider: EntityClassDtoStateProvider::class,
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: QuickLink::class),
 )]
 class QuickLinkApi extends BaseEntityApi
 {
+    #[Groups([SerializationGroups::QUICKLINK_GET])]
     public ?string $name = null;
 
+    #[Groups([SerializationGroups::QUICKLINK_GET])]
     public ?string $linkTo = null;
 }

--- a/backend/src/ApiResource/QuickLinkApi.php
+++ b/backend/src/ApiResource/QuickLinkApi.php
@@ -3,7 +3,6 @@
 namespace App\ApiResource;
 
 use ApiPlatform\Doctrine\Orm\State\Options;
-use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
@@ -55,11 +54,8 @@ use App\State\EntityClassDtoStateProvider;
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: QuickLink::class),
 )]
-class QuickLinkApi
+class QuickLinkApi extends BaseEntityApi
 {
-    #[ApiProperty(readable: false, writable: false, identifier: true)]
-    public ?int $id = null;
-
     public ?string $name = null;
 
     public ?string $linkTo = null;

--- a/backend/src/ApiResource/SearchApi.php
+++ b/backend/src/ApiResource/SearchApi.php
@@ -6,6 +6,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
+use App\Constants\SerializationGroups;
 use App\Controller\Api\SearchController;
 use Symfony\Component\Serializer\Attribute\Groups;
 
@@ -29,7 +30,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
                     )
                 ]
             ),
-            normalizationContext: ['groups' => ['search']],
+            normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::SEARCH]],
             read: false,
         )
     ],
@@ -39,24 +40,24 @@ class SearchApi
     /**
      * @var CourseApi[]
      */
-    #[Groups('search')]
+    #[Groups(SerializationGroups::SEARCH)]
     public array $courses = [];
 
     /**
      * @var ModuleApi[]
      */
-    #[Groups('search')]
+    #[Groups(SerializationGroups::SEARCH)]
     public array $modules = [];
 
     /**
      * @var ProgramApi[]
      */
-    #[Groups('search')]
+    #[Groups(SerializationGroups::SEARCH)]
     public array $programs = [];
 
     /**
      * @var DocumentApi[]
      */
-    #[Groups('search')]
+    #[Groups(SerializationGroups::SEARCH)]
     public array $documents = [];
 }

--- a/backend/src/ApiResource/TagApi.php
+++ b/backend/src/ApiResource/TagApi.php
@@ -8,6 +8,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Post;
+use App\Constants\SerializationGroups;
 use App\Entity\Tag;
 use App\Filter\TagDocumentCategoryFilter;
 use App\Filter\TagDocumentCourseFilter;
@@ -22,6 +23,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
         new GetCollection(),
         new Post(),
     ],
+    normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::TAG_GET]],
     provider: EntityClassDtoStateProvider::class,
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: Tag::class),
@@ -30,12 +32,28 @@ use Symfony\Component\Serializer\Attribute\Groups;
 #[ApiFilter(TagDocumentCourseFilter::class)]
 class TagApi extends BaseEntityApi
 {
-    #[Groups(['search', 'user', 'document:get', 'document:create'])]
+    #[Groups(
+        [
+        SerializationGroups::TAG_GET,
+        SerializationGroups::SEARCH,
+        SerializationGroups::USER,
+        SerializationGroups::DOCUMENT_GET,
+        SerializationGroups::DOCUMENT_CREATE
+        ]
+    )]
     public ?string $name = null;
 
     /**
      * @var DocumentApi[]
      */
-    #[Groups(['search', 'user', 'document:get', 'document:create'])]
+    #[Groups(
+        [
+        SerializationGroups::TAG_GET,
+        SerializationGroups::SEARCH,
+        SerializationGroups::USER,
+        SerializationGroups::DOCUMENT_GET,
+        SerializationGroups::DOCUMENT_CREATE
+        ]
+    )]
     public array $documents = [];
 }

--- a/backend/src/ApiResource/TagApi.php
+++ b/backend/src/ApiResource/TagApi.php
@@ -4,7 +4,6 @@ namespace App\ApiResource;
 
 use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata\ApiFilter;
-use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
@@ -29,11 +28,8 @@ use Symfony\Component\Serializer\Attribute\Groups;
 )]
 #[ApiFilter(TagDocumentCategoryFilter::class)]
 #[ApiFilter(TagDocumentCourseFilter::class)]
-class TagApi
+class TagApi extends BaseEntityApi
 {
-    #[ApiProperty(readable: false, writable: false, identifier: true)]
-    public ?int $id = null;
-
     #[Groups(['search', 'user', 'document:get', 'document:create'])]
     public ?string $name = null;
 

--- a/backend/src/ApiResource/TagApi.php
+++ b/backend/src/ApiResource/TagApi.php
@@ -34,11 +34,11 @@ class TagApi extends BaseEntityApi
 {
     #[Groups(
         [
-        SerializationGroups::TAG_GET,
-        SerializationGroups::SEARCH,
-        SerializationGroups::USER,
-        SerializationGroups::DOCUMENT_GET,
-        SerializationGroups::DOCUMENT_CREATE
+            SerializationGroups::TAG_GET,
+            SerializationGroups::SEARCH,
+            SerializationGroups::USER,
+            SerializationGroups::DOCUMENT_GET,
+            SerializationGroups::DOCUMENT_CREATE
         ]
     )]
     public ?string $name = null;
@@ -48,11 +48,11 @@ class TagApi extends BaseEntityApi
      */
     #[Groups(
         [
-        SerializationGroups::TAG_GET,
-        SerializationGroups::SEARCH,
-        SerializationGroups::USER,
-        SerializationGroups::DOCUMENT_GET,
-        SerializationGroups::DOCUMENT_CREATE
+            SerializationGroups::TAG_GET,
+            SerializationGroups::SEARCH,
+            SerializationGroups::USER,
+            SerializationGroups::DOCUMENT_GET,
+            SerializationGroups::DOCUMENT_CREATE
         ]
     )]
     public array $documents = [];

--- a/backend/src/ApiResource/UserApi.php
+++ b/backend/src/ApiResource/UserApi.php
@@ -58,10 +58,10 @@ class UserApi extends BaseEntityApi
     #[ApiProperty(writable: false)]
     #[Groups(
         [
-        SerializationGroups::USER,
-        SerializationGroups::COURSE_GET,
-        SerializationGroups::DOCUMENT_GET,
-        SerializationGroups::DOCUMENT_COMMENT_GET
+            SerializationGroups::USER,
+            SerializationGroups::COURSE_GET,
+            SerializationGroups::DOCUMENT_GET,
+            SerializationGroups::DOCUMENT_COMMENT_GET
         ]
     )]
     public ?string $fullName = null;

--- a/backend/src/ApiResource/UserApi.php
+++ b/backend/src/ApiResource/UserApi.php
@@ -7,6 +7,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Patch;
+use App\Constants\SerializationGroups;
 use App\Controller\Api\AddFavoriteToUserController;
 use App\Controller\Api\RemoveFavoriteFromUserController;
 use App\Entity\User;
@@ -23,7 +24,7 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: 'is_granted("PATCH_USER", object)',
         ),
     ],
-    normalizationContext: ['groups' => ['user']],
+    normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::USER]],
     provider: EntityClassDtoStateProvider::class,
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: User::class),
@@ -33,17 +34,17 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new Get(
             uriTemplate: 'users/{id}/favorites',
-            normalizationContext: ['groups' => ['user:favorites']],
+            normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::USER_FAVORITES]],
         ),
         new Patch(
             uriTemplate: 'users/{id}/favorites/add',
             controller: AddFavoriteToUserController::class,
-            normalizationContext: ['groups' => ['user:favorites']],
+            normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::USER_FAVORITES]],
         ),
         new Patch(
             uriTemplate: 'users/{id}/favorites/remove',
             controller: RemoveFavoriteFromUserController::class,
-            normalizationContext: ['groups' => ['user:favorites']],
+            normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::USER_FAVORITES]],
         ),
     ],
     security: 'is_granted("VIEW_FAVORITES", object)',
@@ -55,49 +56,56 @@ class UserApi extends BaseEntityApi
 {
     #[Assert\NotBlank]
     #[ApiProperty(writable: false)]
-    #[Groups(['user', 'course:get', 'document:get', 'document_comment:get'])]
+    #[Groups(
+        [
+        SerializationGroups::USER,
+        SerializationGroups::COURSE_GET,
+        SerializationGroups::DOCUMENT_GET,
+        SerializationGroups::DOCUMENT_COMMENT_GET
+        ]
+    )]
     public ?string $fullName = null;
 
     #[Assert\NotBlank]
     #[Assert\Length(min: 2, max: 50)]
     #[ApiProperty(writable: false, security: 'is_granted("VIEW_USERNAME", object)')]
-    #[Groups('user')]
+    #[Groups([SerializationGroups::USER])]
     public ?string $username = null;
 
     #[Assert\Email]
     #[ApiProperty(writable: false, security: 'is_granted("VIEW_EMAIL", object)')]
-    #[Groups('user')]
+    #[Groups([SerializationGroups::USER])]
     public ?string $email = null;
 
     /**
      * @var CourseApi[]
      */
-    #[Groups(['user', 'user:favorites'])]
+    #[Groups([SerializationGroups::USER, SerializationGroups::USER_FAVORITES])]
     #[ApiProperty(security: 'is_granted("VIEW_FAVORITES", object)')]
     public array $favoriteCourses = [];
 
     /**
      * @var ModuleApi[]
      */
-    #[Groups(['user', 'user:favorites'])]
+    #[Groups([SerializationGroups::USER, SerializationGroups::USER_FAVORITES])]
     #[ApiProperty(security: 'is_granted("VIEW_FAVORITES", object)')]
     public array $favoriteModules = [];
 
     /**
      * @var ProgramApi[]
      */
-    #[Groups(['user', 'user:favorites'])]
+    #[Groups([SerializationGroups::USER, SerializationGroups::USER_FAVORITES])]
     #[ApiProperty(security: 'is_granted("VIEW_FAVORITES", object)')]
     public array $favoritePrograms = [];
 
     /**
      * @var DocumentApi[]
      */
-    #[Groups(['user', 'user:favorites'])]
+    #[Groups([SerializationGroups::USER, SerializationGroups::USER_FAVORITES])]
     #[ApiProperty(security: 'is_granted("VIEW_FAVORITES", object)')]
     public array $favoriteDocuments = [];
 
-    #[Groups(['user'])]
+    #[Groups([SerializationGroups::USER])]
     #[ApiProperty(security: 'object === null or is_granted("VIEW_USER_DEFAULT_ANONYMOUS", object)')]
     // object === null is needed to circumvent a specific bug.
     // It is explained more in https://symfonycasts.com/screencast/api-platform-extending/patch-field-security#the-apiproperty-security-option-on-patch-operations

--- a/backend/src/ApiResource/UserApi.php
+++ b/backend/src/ApiResource/UserApi.php
@@ -51,12 +51,8 @@ use Symfony\Component\Validator\Constraints as Assert;
     processor: EntityClassDtoStateProcessor::class,
     stateOptions: new Options(entityClass: User::class),
 )]
-class UserApi
+class UserApi extends BaseEntityApi
 {
-    #[ApiProperty(readable: false, writable: false, identifier: true)]
-    #[Groups('user')]
-    public ?int $id = null;
-
     #[Assert\NotBlank]
     #[ApiProperty(writable: false)]
     #[Groups(['user', 'course:get', 'document:get', 'document_comment:get'])]

--- a/backend/src/ApiResource/UserDocumentViewApi.php
+++ b/backend/src/ApiResource/UserDocumentViewApi.php
@@ -23,11 +23,8 @@ use Symfony\Component\Validator\Constraints as Assert;
     ],
     stateOptions: new Options(entityClass: UserDocumentView::class)
 )]
-class UserDocumentViewApi
+class UserDocumentViewApi extends BaseEntityApi
 {
-    #[ApiProperty(readable: false, writable: false, identifier: true)]
-    public ?int $id = null;
-
     #[Assert\NotNull]
     #[ApiProperty(writable: true)]
     #[Groups(['user:document_views', 'user:document_views:batch'])]

--- a/backend/src/ApiResource/UserDocumentViewApi.php
+++ b/backend/src/ApiResource/UserDocumentViewApi.php
@@ -6,6 +6,7 @@ use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
+use App\Constants\SerializationGroups;
 use App\Entity\UserDocumentView;
 use App\State\UserDocumentViewProvider;
 use DateTimeInterface;
@@ -17,7 +18,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new GetCollection(
             uriTemplate: 'document_views',
-            normalizationContext: ['groups' => ['user:document_views']],
+            normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::USER_DOCUMENT_VIEWS]],
             provider: UserDocumentViewProvider::class,
         ),
     ],
@@ -27,12 +28,12 @@ class UserDocumentViewApi extends BaseEntityApi
 {
     #[Assert\NotNull]
     #[ApiProperty(writable: true)]
-    #[Groups(['user:document_views', 'user:document_views:batch'])]
+    #[Groups([SerializationGroups::USER_DOCUMENT_VIEWS, SerializationGroups::USER_DOCUMENT_VIEWS_BATCH])]
     public DocumentApi $document;
 
     #[Assert\NotNull]
     #[Assert\Type(DateTimeInterface::class)]
     #[ApiProperty(writable: true)]
-    #[Groups(['user:document_views', 'user:document_views:batch'])]
+    #[Groups([SerializationGroups::USER_DOCUMENT_VIEWS, SerializationGroups::USER_DOCUMENT_VIEWS_BATCH])]
     public DateTimeInterface $lastViewed;
 }

--- a/backend/src/Command/AddUserCommand.php
+++ b/backend/src/Command/AddUserCommand.php
@@ -121,12 +121,12 @@ final class AddUserCommand extends Command
         $this->io->title('Add User Command Interactive Wizard');
         $this->io->text(
             [
-            'If you prefer to not use this interactive wizard, provide the',
-            'arguments required by this command as follows:',
-            '',
-            ' $ php bin/console app:add-user username password email@example.com',
-            '',
-            'Now we\'ll ask you for the value of all the missing command arguments.',
+                'If you prefer to not use this interactive wizard, provide the',
+                'arguments required by this command as follows:',
+                '',
+                ' $ php bin/console app:add-user username password email@example.com',
+                '',
+                'Now we\'ll ask you for the value of all the missing command arguments.',
             ]
         );
 
@@ -216,7 +216,7 @@ final class AddUserCommand extends Command
             sprintf(
                 '%s was successfully created: %s (%s)',
                 $isAdmin ?
-                'Administrator user' : 'User',
+                    'Administrator user' : 'User',
                 $user->getUsername(),
                 $user->getEmail()
             )

--- a/backend/src/Command/DeleteUserCommand.php
+++ b/backend/src/Command/DeleteUserCommand.php
@@ -91,13 +91,13 @@ final class DeleteUserCommand extends Command
         $this->io->title('Delete User Command Interactive Wizard');
         $this->io->text(
             [
-            'If you prefer to not use this interactive wizard, provide the',
-            'arguments required by this command as follows:',
-            '',
-            ' $ php bin/console app:delete-user username',
-            '',
-            'Now we\'ll ask you for the value of all the missing command arguments.',
-            '',
+                'If you prefer to not use this interactive wizard, provide the',
+                'arguments required by this command as follows:',
+                '',
+                ' $ php bin/console app:delete-user username',
+                '',
+                'Now we\'ll ask you for the value of all the missing command arguments.',
+                '',
             ]
         );
 
@@ -142,9 +142,11 @@ final class DeleteUserCommand extends Command
         // See https://symfony.com/doc/current/logging.html
         $this->logger->info(
             'User "{username}" (ID: {id}, email: {email}) was successfully deleted.',
-            ['username' => $userUsername,
+            [
+                'username' => $userUsername,
                 'id' => $userId,
-                'email' => $userEmail]
+                'email' => $userEmail
+            ]
         );
 
         return Command::SUCCESS;

--- a/backend/src/Constants/SerializationGroups.php
+++ b/backend/src/Constants/SerializationGroups.php
@@ -11,6 +11,7 @@ final class SerializationGroups
 {
     // Get operations
     public const ANNOUNCEMENT_GET = 'announcement:get';
+    public const COMMENT_CATEGORY_GET = 'comment_category:get';
     public const COURSE_GET = 'course:get';
     public const COURSE_COMMENT_GET = 'course_comment:get';
     public const DOCUMENT_GET = 'document:get';
@@ -20,8 +21,7 @@ final class SerializationGroups
     public const PAGE_GET = 'page:get';
     public const PROGRAM_GET = 'program:get';
     public const TAG_GET = 'tag:get';
-    public const USER_GET = 'user:get';
-    public const USER_DOCUMENT_VIEW_GET = 'user_document_view:get';
+    public const QUICKLINK_GET = 'quicklink:get';
 
     // Create/Write operations
     public const DOCUMENT_CREATE = 'document:create';
@@ -39,29 +39,6 @@ final class SerializationGroups
     // Search and common
     public const SEARCH = 'search';
 
-    /**
-     * All groups used in GET/Read operations.
-     * These are the groups that should include BaseEntity fields.
-     */
-    public const ALL_READ_GROUPS = [
-        self::ANNOUNCEMENT_GET,
-        self::COURSE_GET,
-        self::COURSE_COMMENT_GET,
-        self::DOCUMENT_GET,
-        self::DOCUMENT_CREATE,
-        self::DOCUMENT_CATEGORY_GET,
-        self::DOCUMENT_COMMENT_GET,
-        self::MODULE_GET,
-        self::PAGE_GET,
-        self::PROGRAM_GET,
-        self::TAG_GET,
-        self::USER_GET,
-        self::USER_FAVORITES,
-        self::USER_DOCUMENT_VIEW_GET,
-        self::USER_DOCUMENT_VIEWS,
-        self::USER_DOCUMENT_VIEWS_BATCH,
-        self::VOTE_READ,
-        self::SEARCH,
-        self::USER,
-    ];
+    // Base entity fields group (included in all resource normalizationContext)
+    public const BASE_READ = 'base:read';
 }

--- a/backend/src/Constants/SerializationGroups.php
+++ b/backend/src/Constants/SerializationGroups.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Constants;
+
+/**
+ * Serialization group constants used throughout the API.
+ * These groups are used by the Symfony serializer to control which fields
+ * are included in API responses and requests.
+ */
+final class SerializationGroups
+{
+    // Get operations
+    public const ANNOUNCEMENT_GET = 'announcement:get';
+    public const COURSE_GET = 'course:get';
+    public const COURSE_COMMENT_GET = 'course_comment:get';
+    public const DOCUMENT_GET = 'document:get';
+    public const DOCUMENT_CATEGORY_GET = 'document_category:get';
+    public const DOCUMENT_COMMENT_GET = 'document_comment:get';
+    public const MODULE_GET = 'module:get';
+    public const PAGE_GET = 'page:get';
+    public const PROGRAM_GET = 'program:get';
+    public const TAG_GET = 'tag:get';
+    public const USER_GET = 'user:get';
+    public const USER_DOCUMENT_VIEW_GET = 'user_document_view:get';
+
+    // Create/Write operations
+    public const DOCUMENT_CREATE = 'document:create';
+
+    // User-related groups
+    public const USER = 'user';
+    public const USER_FAVORITES = 'user:favorites';
+    public const USER_DOCUMENT_VIEWS = 'user:document_views';
+    public const USER_DOCUMENT_VIEWS_BATCH = 'user:document_views:batch';
+
+    // Vote-related groups
+    public const VOTE_READ = 'vote:read';
+    public const VOTE_WRITE = 'vote:write';
+
+    // Search and common
+    public const SEARCH = 'search';
+
+    /**
+     * All groups used in GET/Read operations.
+     * These are the groups that should include BaseEntity fields.
+     */
+    public const ALL_READ_GROUPS = [
+        self::ANNOUNCEMENT_GET,
+        self::COURSE_GET,
+        self::COURSE_COMMENT_GET,
+        self::DOCUMENT_GET,
+        self::DOCUMENT_CREATE,
+        self::DOCUMENT_CATEGORY_GET,
+        self::DOCUMENT_COMMENT_GET,
+        self::MODULE_GET,
+        self::PAGE_GET,
+        self::PROGRAM_GET,
+        self::TAG_GET,
+        self::USER_GET,
+        self::USER_FAVORITES,
+        self::USER_DOCUMENT_VIEW_GET,
+        self::USER_DOCUMENT_VIEWS,
+        self::USER_DOCUMENT_VIEWS_BATCH,
+        self::VOTE_READ,
+        self::SEARCH,
+        self::USER,
+    ];
+}

--- a/backend/src/Controller/Admin/CommentCategoryCrudController.php
+++ b/backend/src/Controller/Admin/CommentCategoryCrudController.php
@@ -31,7 +31,7 @@ class CommentCategoryCrudController extends AbstractCrudController
     public function configureFields(string $pageName): iterable
     {
         yield IdField::new('id')->onlyOnDetail();
-        yield Textfield::new('name_nl')
+        yield TextField::new('name_nl')
             ->setRequired(true)
             ->setLabel('Name (NL)');
         yield TextEditorField::new('description_nl')
@@ -40,7 +40,7 @@ class CommentCategoryCrudController extends AbstractCrudController
 
         yield FormField::addFieldset('English Content')->setIcon('fa fa-language')
             ->collapsible();
-        yield Textfield::new('name_en')
+        yield TextField::new('name_en')
             ->setLabel('Name (EN)');
         yield TextEditorField::new('description_en')
             ->setLabel('Description (EN)')

--- a/backend/src/Controller/Admin/CourseCommentCrudController.php
+++ b/backend/src/Controller/Admin/CourseCommentCrudController.php
@@ -51,9 +51,9 @@ class CourseCommentCrudController extends AbstractCrudController
             ->autocomplete();
         yield AssociationField::new('category')
             ->autocomplete();
-        yield DateTimeField::new('createDate')
+        yield DateTimeField::new('createdAt')
             ->hideOnForm();
-        yield DateTimeField::new('updateDate')
+        yield DateTimeField::new('updatedAt')
             ->hideOnForm();
     }
 
@@ -65,7 +65,7 @@ class CourseCommentCrudController extends AbstractCrudController
             ->add('content')
             ->add(EntityContainsFilter::new('creator', User::class))
             ->add('anonymous')
-            ->add('createDate')
-            ->add('updateDate');
+            ->add('createdAt')
+            ->add('updatedAt');
     }
 }

--- a/backend/src/Controller/Admin/CourseCrudController.php
+++ b/backend/src/Controller/Admin/CourseCrudController.php
@@ -32,8 +32,8 @@ class CourseCrudController extends AbstractCrudController
         yield ChoiceField::new('language')
             ->setChoices(
                 [
-                'Dutch' => 'nl',
-                'English' => 'en',
+                    'Dutch' => 'nl',
+                    'English' => 'en',
                 ]
             );
         yield AssociationField::new('modules')

--- a/backend/src/Controller/Admin/DashboardController.php
+++ b/backend/src/Controller/Admin/DashboardController.php
@@ -16,9 +16,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 #[AdminDashboard(routePath: '/admin', routeName: 'admin')]
 class DashboardController extends AbstractDashboardController
 {
-    public function __construct(private readonly DocumentRepository $documentRepository)
-    {
-    }
+    public function __construct(private readonly DocumentRepository $documentRepository) {}
 
     public function index(): Response
     {

--- a/backend/src/Controller/Admin/DocumentBulkUploadController.php
+++ b/backend/src/Controller/Admin/DocumentBulkUploadController.php
@@ -13,12 +13,12 @@ use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
-use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\File\File;
@@ -27,9 +27,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\File as FileConstraint;
+use Symfony\Component\Validator\Constraints\NotNull;
 
 #[IsGranted(User::ROLE_MODERATOR)]
 class DocumentBulkUploadController extends AbstractController
@@ -40,8 +40,7 @@ class DocumentBulkUploadController extends AbstractController
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly RequestStack $requestStack,
-    ) {
-    }
+    ) {}
 
     #[AdminRoute('/bulk-upload', name: 'bulk_upload_index')]
     public function index(): Response

--- a/backend/src/Controller/Admin/DocumentCommentCrudController.php
+++ b/backend/src/Controller/Admin/DocumentCommentCrudController.php
@@ -49,8 +49,8 @@ class DocumentCommentCrudController extends AbstractCrudController
         yield AssociationField::new('document')
             ->autocomplete()
             ->setCrudController(DocumentCrudController::class);
-            // Explicit reference needed because there are multiple crudcontrollers for Document
-            // See https://symfonycasts.com/screencast/easyadminbundle/multiple-crud#autocomplete-and-multiple-crud-controllers
+        // Explicit reference needed because there are multiple crudcontrollers for Document
+        // See https://symfonycasts.com/screencast/easyadminbundle/multiple-crud#autocomplete-and-multiple-crud-controllers
         yield DateTimeField::new('createdAt')
             ->hideOnForm();
         yield DateTimeField::new('updatedAt')

--- a/backend/src/Controller/Admin/DocumentCommentCrudController.php
+++ b/backend/src/Controller/Admin/DocumentCommentCrudController.php
@@ -51,9 +51,9 @@ class DocumentCommentCrudController extends AbstractCrudController
             ->setCrudController(DocumentCrudController::class);
             // Explicit reference needed because there are multiple crudcontrollers for Document
             // See https://symfonycasts.com/screencast/easyadminbundle/multiple-crud#autocomplete-and-multiple-crud-controllers
-        yield DateTimeField::new('createDate')
+        yield DateTimeField::new('createdAt')
             ->hideOnForm();
-        yield DateTimeField::new('updateDate')
+        yield DateTimeField::new('updatedAt')
             ->hideOnForm();
     }
 
@@ -64,7 +64,7 @@ class DocumentCommentCrudController extends AbstractCrudController
             ->add(EntityContainsFilter::new('creator', User::class))
             ->add('anonymous')
             ->add(EntityContainsFilter::new('document', DocumentComment::class))
-            ->add('createDate')
-            ->add('updateDate');
+            ->add('createdAt')
+            ->add('updatedAt');
     }
 }

--- a/backend/src/Controller/Admin/DocumentCrudController.php
+++ b/backend/src/Controller/Admin/DocumentCrudController.php
@@ -70,8 +70,8 @@ class DocumentCrudController extends AbstractCrudController
             ->setFormType(VichFileType::class)
             ->setFormTypeOptions(
                 [
-                'download_label' => true,
-                'allow_delete' => false,
+                    'download_label' => true,
+                    'allow_delete' => false,
                 ]
             )
             ->hideOnIndex();
@@ -86,7 +86,7 @@ class DocumentCrudController extends AbstractCrudController
             ->add('year')
             ->add(EntityContainsFilter::new('course', Course::class))
             ->add(EntityContainsFilter::new('category', DocumentCategory::class))
-            ->add(EntityContainsFilter::new('tags', Tag ::class))
+            ->add(EntityContainsFilter::new('tags', Tag::class))
             ->add('under_review')
             ->add('anonymous');
     }

--- a/backend/src/Controller/Admin/DocumentCrudController.php
+++ b/backend/src/Controller/Admin/DocumentCrudController.php
@@ -39,9 +39,9 @@ class DocumentCrudController extends AbstractCrudController
     public function configureFields(string $pageName): iterable
     {
         yield TextField::new('name');
-        yield DateTimeField::new('createDate')
+        yield DateTimeField::new('createdAt')
             ->hideOnForm();
-        yield DateTimeField::new('updateDate')
+        yield DateTimeField::new('updatedAt')
             ->hideOnForm();
         yield AssociationField::new('course')
             ->autocomplete();

--- a/backend/src/Controller/Admin/DocumentPendingCrudController.php
+++ b/backend/src/Controller/Admin/DocumentPendingCrudController.php
@@ -74,9 +74,9 @@ class DocumentPendingCrudController extends DocumentCrudController
     public function configureFields(string $pageName): iterable
     {
         yield TextField::new('name');
-        yield DateTimeField::new('createDate')
+        yield DateTimeField::new('createdAt')
             ->hideOnForm();
-        yield DateTimeField::new('updateDate')
+        yield DateTimeField::new('updatedAt')
             ->hideOnForm();
         yield AssociationField::new('category')
             ->autocomplete();

--- a/backend/src/Controller/Admin/DocumentPendingCrudController.php
+++ b/backend/src/Controller/Admin/DocumentPendingCrudController.php
@@ -106,8 +106,8 @@ class DocumentPendingCrudController extends DocumentCrudController
             ->setFormType(VichFileType::class)
             ->setFormTypeOptions(
                 [
-                'download_label' => true,
-                'allow_delete' => false,
+                    'download_label' => true,
+                    'allow_delete' => false,
                 ]
             )
             ->hideOnIndex();

--- a/backend/src/Controller/Admin/Filter/ArrayContainsFilter.php
+++ b/backend/src/Controller/Admin/Filter/ArrayContainsFilter.php
@@ -23,19 +23,19 @@ class ArrayContainsFilter implements FilterInterface
             ->setFormType(ChoiceFilterType::class)
             ->setFormTypeOptions(
                 [
-                'value_type_options' => [
-                    'choices' => $choices,
-                    'multiple' => true,
-                ],
-                'comparison_type_options' => [
-                    'choices' => [
-                        'Contains Any' => 'CONTAINS_ANY',
-                        'Contains All' => 'CONTAINS_ALL',
-                        'Is Same' => 'IN',
-                        'Is Not Same' => 'NOT IN',
+                    'value_type_options' => [
+                        'choices' => $choices,
+                        'multiple' => true,
                     ],
-                ],
-                'translation_domain' => 'EasyAdminBundle',
+                    'comparison_type_options' => [
+                        'choices' => [
+                            'Contains Any' => 'CONTAINS_ANY',
+                            'Contains All' => 'CONTAINS_ALL',
+                            'Is Same' => 'IN',
+                            'Is Not Same' => 'NOT IN',
+                        ],
+                    ],
+                    'translation_domain' => 'EasyAdminBundle',
                 ]
             );
     }

--- a/backend/src/Controller/Admin/Filter/EntityContainsFilter.php
+++ b/backend/src/Controller/Admin/Filter/EntityContainsFilter.php
@@ -25,19 +25,19 @@ class EntityContainsFilter implements FilterInterface
             ->setFormType(EntityFilterType::class)
             ->setFormTypeOptions(
                 [
-                'value_type_options' => [
-                    'class' => $entityClass,
-                    'multiple' => true,
-                ],
-                'comparison_type_options' => [
-                    'choices' => [
-                        'Contains Any' => 'CONTAINS_ANY',
-                        'Contains All' => 'CONTAINS_ALL',
-                        'Is Same' => 'IN',
-                        'Is Not Same' => 'NOT IN',
+                    'value_type_options' => [
+                        'class' => $entityClass,
+                        'multiple' => true,
                     ],
-                ],
-                'translation_domain' => 'EasyAdminBundle',
+                    'comparison_type_options' => [
+                        'choices' => [
+                            'Contains Any' => 'CONTAINS_ANY',
+                            'Contains All' => 'CONTAINS_ALL',
+                            'Is Same' => 'IN',
+                            'Is Not Same' => 'NOT IN',
+                        ],
+                    ],
+                    'translation_domain' => 'EasyAdminBundle',
                 ]
             );
     }

--- a/backend/src/Controller/Admin/PageCrudController.php
+++ b/backend/src/Controller/Admin/PageCrudController.php
@@ -28,11 +28,11 @@ class PageCrudController extends AbstractCrudController
 
     public function configureFields(string $pageName): iterable
     {
-        yield Textfield::new('urlKey')
+        yield TextField::new('urlKey')
             ->setHelp('The URL key is used to generate the URL of the page.');
         yield BooleanField::new('publicAvailable')
             ->renderAsSwitch(false);
-        yield Textfield::new('name_nl')
+        yield TextField::new('name_nl')
             ->setRequired(true)
             ->setLabel('Name (NL)');
         yield TextEditorField::new('content_nl')
@@ -42,7 +42,7 @@ class PageCrudController extends AbstractCrudController
         yield FormField::addFieldset('English Content')->setIcon('fa fa-language')
             ->collapsible()
             ->renderCollapsed();
-        yield Textfield::new('name_en')
+        yield TextField::new('name_en')
             ->setLabel('Name (EN)');
         yield TextEditorField::new('content_en')
             ->setLabel('Content (EN)')

--- a/backend/src/Controller/Admin/UserCrudController.php
+++ b/backend/src/Controller/Admin/UserCrudController.php
@@ -28,8 +28,7 @@ class UserCrudController extends AbstractCrudController
 {
     public function __construct(
         private UserPasswordHasherInterface $passwordHasher
-    ) {
-    }
+    ) {}
 
     public static function getEntityFqcn(): string
     {

--- a/backend/src/Controller/Api/AddDocumentViewToUserController.php
+++ b/backend/src/Controller/Api/AddDocumentViewToUserController.php
@@ -25,8 +25,7 @@ class AddDocumentViewToUserController extends AbstractController
         private readonly EntityManagerInterface $entityManager,
         private readonly IriConverterInterface $iriConverter,
         private readonly UserDocumentViewRepository $viewRepository,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception

--- a/backend/src/Controller/Api/AddFavoriteToUserController.php
+++ b/backend/src/Controller/Api/AddFavoriteToUserController.php
@@ -30,8 +30,7 @@ class AddFavoriteToUserController extends AbstractController
         private readonly EntityManagerInterface $entityManager,
         private readonly SerializerInterface $serializer,
         private readonly IriConverterInterface $iriConverter,
-    ) {
-    }
+    ) {}
 
     public function __invoke(UserApi $userApi, Request $request)
     {
@@ -55,7 +54,7 @@ class AddFavoriteToUserController extends AbstractController
                 $courseApi,
                 Course::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
 
@@ -69,7 +68,7 @@ class AddFavoriteToUserController extends AbstractController
                 $moduleApi,
                 Module::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
             $user->addFavoriteModule($module);
@@ -81,7 +80,7 @@ class AddFavoriteToUserController extends AbstractController
                 $programApi,
                 Program::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
             $user->addFavoriteProgram($program);
@@ -93,7 +92,7 @@ class AddFavoriteToUserController extends AbstractController
                 $documentApi,
                 Document::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
             $user->addFavoriteDocument($document);
@@ -105,7 +104,7 @@ class AddFavoriteToUserController extends AbstractController
             $user,
             UserApi::class,
             [
-            MicroMapperInterface::MAX_DEPTH => 1,
+                MicroMapperInterface::MAX_DEPTH => 1,
             ]
         );
         $serializedUserApi = $this->serializer->serialize(

--- a/backend/src/Controller/Api/CreateDocumentController.php
+++ b/backend/src/Controller/Api/CreateDocumentController.php
@@ -23,8 +23,7 @@ class CreateDocumentController extends AbstractController
         private readonly IriConverterInterface $iriConverter,
         private readonly MicroMapperInterface $microMapper,
         private readonly StorageInterface $storage,
-    ) {
-    }
+    ) {}
 
     public function __invoke(Request $request): DocumentApi
     {
@@ -36,13 +35,13 @@ class CreateDocumentController extends AbstractController
         /** @var CourseApi $course */
         $course = $this->iriConverter->getResourceFromIri(
             $request->request->get('course') ??
-            throw new BadRequestHttpException('"course" is required')
+                throw new BadRequestHttpException('"course" is required')
         );
         $dto->course = $course;
         /** @var DocumentCategoryApi $category */
         $category = $this->iriConverter->getResourceFromIri(
             $request->request->get('category') ??
-            throw new BadRequestHttpException('"category" is required')
+                throw new BadRequestHttpException('"category" is required')
         );
         $dto->category = $category;
 

--- a/backend/src/Controller/Api/CreateVoteController.php
+++ b/backend/src/Controller/Api/CreateVoteController.php
@@ -29,8 +29,7 @@ class CreateVoteController extends AbstractController
         private readonly Security $security,
         private readonly SerializerInterface $serializer,
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     public function __invoke(Request $request): JsonResponse
     {

--- a/backend/src/Controller/Api/DeleteVoteController.php
+++ b/backend/src/Controller/Api/DeleteVoteController.php
@@ -20,8 +20,7 @@ class DeleteVoteController extends AbstractController
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly Security $security,
-    ) {
-    }
+    ) {}
 
     public function __invoke(Request $request): JsonResponse
     {

--- a/backend/src/Controller/Api/DownloadZipController.php
+++ b/backend/src/Controller/Api/DownloadZipController.php
@@ -785,13 +785,13 @@ final class DownloadZipController extends AbstractController
         // Create date
         $html .= '<div class="metadata-pair">';
         $html .= '<span class="metadata-label">Created:</span>';
-        $html .= '<span class="metadata-value">' . $document->getCreateDate()->format('Y-m-d') . '</span>';
+        $html .= '<span class="metadata-value">' . $document->getCreatedAt()->format('Y-m-d') . '</span>';
         $html .= '</div>';
 
         // Update date
         $html .= '<div class="metadata-pair">';
         $html .= '<span class="metadata-label">Updated:</span>';
-        $html .= '<span class="metadata-value">' . $document->getUpdateDate()->format('Y-m-d') . '</span>';
+        $html .= '<span class="metadata-value">' . $document->getUpdatedAt()->format('Y-m-d') . '</span>';
         $html .= '</div>';
 
         // Add file size if we can calculate it

--- a/backend/src/Controller/Api/DownloadZipController.php
+++ b/backend/src/Controller/Api/DownloadZipController.php
@@ -27,8 +27,7 @@ final class DownloadZipController extends AbstractController
         private readonly DocumentRepository $documentRepository,
         private readonly StorageInterface $storage,
         private readonly KernelInterface $kernel,
-    ) {
-    }
+    ) {}
 
     public function __invoke(ZipApi $zipApi): Response
     {

--- a/backend/src/Controller/Api/GetVoteSummaryController.php
+++ b/backend/src/Controller/Api/GetVoteSummaryController.php
@@ -17,8 +17,7 @@ class GetVoteSummaryController extends AbstractController
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
-    ) {
-    }
+    ) {}
 
     public function __invoke(Request $request): VoteSummaryApi
     {

--- a/backend/src/Controller/Api/HealthcheckController.php
+++ b/backend/src/Controller/Api/HealthcheckController.php
@@ -12,8 +12,7 @@ class HealthcheckController extends AbstractController
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
-    ) {
-    }
+    ) {}
 
     public function __invoke(): JsonResponse
     {
@@ -24,21 +23,21 @@ class HealthcheckController extends AbstractController
 
             return new JsonResponse(
                 [
-                'status' => 'ok',
-                'timestamp' => date('c'),
-                'service' => 'burgieclan-api',
-                'database' => 'connected'
+                    'status' => 'ok',
+                    'timestamp' => date('c'),
+                    'service' => 'burgieclan-api',
+                    'database' => 'connected'
                 ],
                 Response::HTTP_OK
             );
         } catch (Exception $e) {
             return new JsonResponse(
                 [
-                'status' => 'error',
-                'timestamp' => date('c'),
-                'service' => 'burgieclan-api',
-                'database' => 'disconnected',
-                'error' => $e->getMessage()
+                    'status' => 'error',
+                    'timestamp' => date('c'),
+                    'service' => 'burgieclan-api',
+                    'database' => 'disconnected',
+                    'error' => $e->getMessage()
                 ],
                 Response::HTTP_SERVICE_UNAVAILABLE
             );

--- a/backend/src/Controller/Api/LitusOAuthCallbackController.php
+++ b/backend/src/Controller/Api/LitusOAuthCallbackController.php
@@ -26,8 +26,7 @@ class LitusOAuthCallbackController extends AbstractController
         private readonly UserRepository $userRepository,
         private readonly ClientRegistry $clientRegistry,
         private readonly LoggerInterface $logger
-    ) {
-    }
+    ) {}
 
     public function __invoke(Request $request): RedirectResponse
     {

--- a/backend/src/Controller/Api/LitusOAuthInitiateController.php
+++ b/backend/src/Controller/Api/LitusOAuthInitiateController.php
@@ -12,8 +12,7 @@ class LitusOAuthInitiateController extends AbstractController
 {
     public function __construct(
         private readonly ClientRegistry $clientRegistry
-    ) {
-    }
+    ) {}
 
 
     public function __invoke(Request $request): RedirectResponse

--- a/backend/src/Controller/Api/RemoveFavoriteFromUserController.php
+++ b/backend/src/Controller/Api/RemoveFavoriteFromUserController.php
@@ -30,8 +30,7 @@ class RemoveFavoriteFromUserController extends AbstractController
         private readonly EntityManagerInterface $entityManager,
         private readonly SerializerInterface $serializer,
         private readonly IriConverterInterface $iriConverter,
-    ) {
-    }
+    ) {}
 
     public function __invoke(UserApi $userApi, Request $request)
     {
@@ -55,7 +54,7 @@ class RemoveFavoriteFromUserController extends AbstractController
                 $courseApi,
                 Course::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
 
@@ -69,7 +68,7 @@ class RemoveFavoriteFromUserController extends AbstractController
                 $moduleApi,
                 Module::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
             $user->removeFavoriteModule($module);
@@ -81,7 +80,7 @@ class RemoveFavoriteFromUserController extends AbstractController
                 $programApi,
                 Program::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
             $user->removeFavoriteProgram($program);
@@ -93,7 +92,7 @@ class RemoveFavoriteFromUserController extends AbstractController
                 $documentApi,
                 Document::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
             $user->removeFavoriteDocument($document);
@@ -106,7 +105,7 @@ class RemoveFavoriteFromUserController extends AbstractController
             $user,
             UserApi::class,
             [
-            MicroMapperInterface::MAX_DEPTH => 1,
+                MicroMapperInterface::MAX_DEPTH => 1,
             ]
         );
         $serializedUserApi = $this->serializer->serialize(

--- a/backend/src/Controller/Api/SearchController.php
+++ b/backend/src/Controller/Api/SearchController.php
@@ -27,8 +27,7 @@ class SearchController extends AbstractController
         private readonly ProgramRepository $programRepository,
         private readonly DocumentRepository $documentRepository,
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     public function __invoke(Request $request)
     {

--- a/backend/src/Controller/SecurityController.php
+++ b/backend/src/Controller/SecurityController.php
@@ -56,10 +56,10 @@ final class SecurityController extends AbstractController
         return $this->render(
             'security/login.html.twig',
             [
-            // last username entered by the user (if any)
-            'last_username' => $helper->getLastUsername(),
-            // last authentication error (if any)
-            'error' => $helper->getLastAuthenticationError(),
+                // last username entered by the user (if any)
+                'last_username' => $helper->getLastUsername(),
+                // last authentication error (if any)
+                'error' => $helper->getLastAuthenticationError(),
             ]
         );
     }

--- a/backend/src/DataFixtures/AppFixtures.php
+++ b/backend/src/DataFixtures/AppFixtures.php
@@ -36,8 +36,7 @@ final class AppFixtures extends Fixture
 {
     public function __construct(
         private readonly UserPasswordHasherInterface $passwordHasher,
-    ) {
-    }
+    ) {}
 
     public function load(ObjectManager $manager): void
     {

--- a/backend/src/Entity/AbstractVote.php
+++ b/backend/src/Entity/AbstractVote.php
@@ -9,22 +9,12 @@ abstract class AbstractVote extends Node
     public const UPVOTE = 1;
     public const DOWNVOTE = -1;
 
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column]
-    protected ?int $id = null;
-
     #[ORM\Column]
     protected ?int $voteType = null;
 
     public function __construct(User $creator)
     {
         parent::__construct($creator);
-    }
-
-    public function getId(): ?int
-    {
-        return $this->id;
     }
 
     public function getVoteType(): ?int

--- a/backend/src/Entity/Announcement.php
+++ b/backend/src/Entity/Announcement.php
@@ -11,11 +11,6 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Table(name: 'announcement')]
 class Announcement extends Node
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private ?int $id = null;
-
     #[ORM\Column(type: Types::BOOLEAN)]
     private bool $priority;
 
@@ -45,11 +40,6 @@ class Announcement extends Node
     ];
 
     public static string $DEFAULT_LANGUAGE = 'nl';
-
-    public function getId(): ?int
-    {
-        return $this->id;
-    }
 
     public function getStartTime(): DateTime
     {

--- a/backend/src/Entity/BaseEntity.php
+++ b/backend/src/Entity/BaseEntity.php
@@ -2,7 +2,7 @@
 
 namespace App\Entity;
 
-use DateTime;
+use DateTimeImmutable;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -21,22 +21,22 @@ abstract class BaseEntity
     protected ?int $id = null;
 
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
-    protected DateTime $createdAt;
+    protected DateTimeImmutable $createdAt;
 
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
-    protected DateTime $updatedAt;
+    protected DateTimeImmutable $updatedAt;
 
     public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function getCreatedAt(): DateTime
+    public function getCreatedAt(): DateTimeImmutable
     {
         return $this->createdAt;
     }
 
-    public function getUpdatedAt(): DateTime
+    public function getUpdatedAt(): DateTimeImmutable
     {
         return $this->updatedAt;
     }
@@ -44,14 +44,14 @@ abstract class BaseEntity
     #[ORM\PrePersist]
     public function onPrePersist(): void
     {
-        $this->createdAt = $this->createdAt ?? new DateTime("now");
+        $this->createdAt = $this->createdAt ?? new DateTimeImmutable("now");
         $this->updatedAt = $this->createdAt;
     }
 
     #[ORM\PreUpdate]
     public function onPreUpdate(): void
     {
-        $this->updatedAt = new DateTime("now");
+        $this->updatedAt = new DateTimeImmutable("now");
     }
 
     public function __toString(): string

--- a/backend/src/Entity/BaseEntity.php
+++ b/backend/src/Entity/BaseEntity.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Entity;
+
+use DateTime;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Base entity class providing common functionality for all entities.
+ * Uses PostgreSQL IDENTITY columns for auto-incrementing IDs.
+ * Automatically manages creation and update timestamps.
+ */
+#[ORM\MappedSuperclass]
+#[ORM\HasLifecycleCallbacks]
+abstract class BaseEntity
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    protected ?int $id = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    protected DateTime $createdAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    protected DateTime $updatedAt;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getCreatedAt(): DateTime
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTime
+    {
+        return $this->updatedAt;
+    }
+
+    #[ORM\PrePersist]
+    public function onPrePersist(): void
+    {
+        $this->createdAt = $this->createdAt ?? new DateTime("now");
+        $this->updatedAt = $this->createdAt;
+    }
+
+    #[ORM\PreUpdate]
+    public function onPreUpdate(): void
+    {
+        $this->updatedAt = new DateTime("now");
+    }
+
+    public function __toString(): string
+    {
+        return sprintf("%s - %s", get_class($this), $this->id);
+    }
+}

--- a/backend/src/Entity/CommentCategory.php
+++ b/backend/src/Entity/CommentCategory.php
@@ -8,13 +8,8 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: CommentCategoryRepository::class)]
-class CommentCategory
+class CommentCategory extends BaseEntity
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column]
-    private ?int $id = null;
-
     public static array $AVAILABLE_LANGUAGES = [
         'nl' => 'Dutch',
         'en' => 'English',
@@ -39,11 +34,6 @@ class CommentCategory
     public function __toString(): string
     {
         return sprintf('%s (%s)', $this->getNameNl(), $this->getNameEn());
-    }
-
-    public function getId(): ?int
-    {
-        return $this->id;
     }
 
     public function getName(string $lang): ?string

--- a/backend/src/Entity/Course.php
+++ b/backend/src/Entity/Course.php
@@ -17,17 +17,12 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 #[ORM\Entity(repositoryClass: CourseRepository::class)]
 #[ORM\Table(name: 'course')]
-class Course
+class Course extends BaseEntity
 {
     final public const SEMESTERS = [
         'Semester 1' => 'Semester 1',
         'Semester 2' => 'Semester 2',
     ];
-
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column]
-    private ?int $id = null;
 
     #[ORM\Column(type: Types::STRING, length: 255)]
     #[Assert\NotBlank]
@@ -96,11 +91,6 @@ class Course
     public function __toString(): string
     {
         return sprintf('%s (%s)', $this->getName(), $this->getCode());
-    }
-
-    public function getId(): ?int
-    {
-        return $this->id;
     }
 
     public function getName(): string

--- a/backend/src/Entity/CourseComment.php
+++ b/backend/src/Entity/CourseComment.php
@@ -10,11 +10,6 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: CourseCommentRepository::class)]
 class CourseComment extends AbstractComment implements VotableInterface
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column]
-    private ?int $id = null;
-
     #[ORM\ManyToOne(inversedBy: 'courseComments')]
     #[ORM\JoinColumn(nullable: false)]
     private Course $course;
@@ -43,11 +38,6 @@ class CourseComment extends AbstractComment implements VotableInterface
     public function __toString(): string
     {
         return sprintf('%s (%s)', $this->getContent(), $this->getCourse()->getName());
-    }
-
-    public function getId(): ?int
-    {
-        return $this->id;
     }
 
     public function getCourse(): Course

--- a/backend/src/Entity/Document.php
+++ b/backend/src/Entity/Document.php
@@ -14,11 +14,6 @@ use Vich\UploaderBundle\Mapping\Attribute as Vich;
 #[ORM\Entity(repositoryClass: DocumentRepository::class)]
 class Document extends Node implements VotableInterface
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column]
-    private ?int $id = null;
-
     #[ORM\Column(length: 255)]
     private string $name;
 
@@ -70,11 +65,6 @@ class Document extends Node implements VotableInterface
         parent::__construct($creator);
         $this->tags = new ArrayCollection();
         $this->votes = new ArrayCollection();
-    }
-
-    public function getId(): ?int
-    {
-        return $this->id;
     }
 
     public function getName(): string
@@ -171,7 +161,7 @@ class Document extends Node implements VotableInterface
         if (null !== $file) {
             // It is required that at least one field changes if you are using doctrine
             // otherwise the event listeners won't be called and the file is lost
-            $this->setUpdateDate();
+            $this->onPreUpdate();
         }
     }
 

--- a/backend/src/Entity/DocumentCategory.php
+++ b/backend/src/Entity/DocumentCategory.php
@@ -6,13 +6,8 @@ use App\Repository\DocumentCategoryRepository;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: DocumentCategoryRepository::class)]
-class DocumentCategory
+class DocumentCategory extends BaseEntity
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column]
-    private ?int $id = null;
-
     public static array $AVAILABLE_LANGUAGES = [
         'nl' => 'Dutch',
         'en' => 'English',
@@ -25,11 +20,6 @@ class DocumentCategory
 
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $name_en = null;
-
-    public function getId(): ?int
-    {
-        return $this->id;
-    }
 
     public function __toString(): string
     {

--- a/backend/src/Entity/DocumentComment.php
+++ b/backend/src/Entity/DocumentComment.php
@@ -10,11 +10,6 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: DocumentCommentRepository::class)]
 class DocumentComment extends AbstractComment implements VotableInterface
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column]
-    private ?int $id = null;
-
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     private Document $document;
@@ -39,11 +34,6 @@ class DocumentComment extends AbstractComment implements VotableInterface
     public function __toString(): string
     {
         return sprintf('%s (%s)', $this->getContent(), $this->getDocument()->getName());
-    }
-
-    public function getId(): ?int
-    {
-        return $this->id;
     }
 
     public function getDocument(): Document

--- a/backend/src/Entity/Module.php
+++ b/backend/src/Entity/Module.php
@@ -8,13 +8,8 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: ModuleRepository::class)]
-class Module
+class Module extends BaseEntity
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column]
-    private ?int $id = null;
-
     #[ORM\Column(length: 255)]
     private string $name;
 
@@ -43,11 +38,6 @@ class Module
     public function __toString(): string
     {
         return $this->getName();
-    }
-
-    public function getId(): ?int
-    {
-        return $this->id;
     }
 
     public function getName(): string

--- a/backend/src/Entity/Node.php
+++ b/backend/src/Entity/Node.php
@@ -9,23 +9,15 @@ use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\MappedSuperclass]
 #[ORM\HasLifecycleCallbacks]
-abstract class Node
+abstract class Node extends BaseEntity
 {
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     private User $creator;
 
-    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
-    protected DateTimeImmutable $createDate;
-
-    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    protected DateTime $updateDate;
-
     public function __construct(User $creator)
     {
         $this->creator = $creator;
-        $this->createDate = new DateTimeImmutable();
-        $this->updateDate = new DateTime();
     }
 
     public function getCreator(): User
@@ -36,25 +28,6 @@ abstract class Node
     public function setCreator(User $creator): static
     {
         $this->creator = $creator;
-
-        return $this;
-    }
-
-    public function getCreateDate(): DateTimeImmutable
-    {
-        return $this->createDate;
-    }
-
-    public function getUpdateDate(): DateTime
-    {
-        return $this->updateDate;
-    }
-
-    // can be used to update the date when the node is updated
-    #[ORM\PreUpdate]
-    public function setUpdateDate(): self
-    {
-        $this->updateDate = new DateTime();
 
         return $this;
     }

--- a/backend/src/Entity/Node.php
+++ b/backend/src/Entity/Node.php
@@ -2,9 +2,6 @@
 
 namespace App\Entity;
 
-use DateTime;
-use DateTimeImmutable;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\MappedSuperclass]

--- a/backend/src/Entity/Page.php
+++ b/backend/src/Entity/Page.php
@@ -7,13 +7,8 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: PageRepository::class)]
-class Page
+class Page extends BaseEntity
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column]
-    private ?int $id = null;
-
     #[ORM\Column(length: 255, unique: true)]
     private string $urlKey;
 
@@ -48,11 +43,6 @@ class Page
     public function __construct(?string $urlKey = null)
     {
         $this->urlKey = self::createUrlKey($urlKey);
-    }
-
-    public function getId(): ?int
-    {
-        return $this->id;
     }
 
     public function getUrlKey(): ?string

--- a/backend/src/Entity/Program.php
+++ b/backend/src/Entity/Program.php
@@ -8,13 +8,8 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: ProgramRepository::class)]
-class Program
+class Program extends BaseEntity
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column]
-    private ?int $id = null;
-
     #[ORM\Column(length: 255)]
     private string $name;
 
@@ -32,11 +27,6 @@ class Program
     public function __toString(): string
     {
         return $this->getName();
-    }
-
-    public function getId(): ?int
-    {
-        return $this->id;
     }
 
     public function getName(): string

--- a/backend/src/Entity/QuickLink.php
+++ b/backend/src/Entity/QuickLink.php
@@ -6,13 +6,8 @@ use App\Repository\QuickLinkRepository;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: QuickLinkRepository::class)]
-class QuickLink
+class QuickLink extends BaseEntity
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column]
-    private ?int $id = null;
-
     public static string $DEFAULT_LANGUAGE = 'nl';
 
     #[ORM\Column(length: 255, nullable: true)]
@@ -23,11 +18,6 @@ class QuickLink
 
     #[ORM\Column(length: 255)]
     private string $linkTo;
-
-    public function getId(): ?int
-    {
-        return $this->id;
-    }
 
     public function getName(string $lang): ?string
     {

--- a/backend/src/Entity/Tag.php
+++ b/backend/src/Entity/Tag.php
@@ -8,13 +8,8 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: TagRepository::class)]
-class Tag
+class Tag extends BaseEntity
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column]
-    private ?int $id = null;
-
     #[ORM\Column(length: 255, unique: true)]
     private string $name;
 
@@ -27,11 +22,6 @@ class Tag
     public function __construct()
     {
         $this->documents = new ArrayCollection();
-    }
-
-    public function getId(): ?int
-    {
-        return $this->id;
     }
 
     public function getName(): ?string

--- a/backend/src/Entity/User.php
+++ b/backend/src/Entity/User.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 #[ORM\Table(name: 'burgieclan_user')]
-class User implements UserInterface, PasswordAuthenticatedUserInterface
+class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUserInterface
 {
     // We can use constants for roles to find usages all over the application rather
     // than doing a full-text search on the "ROLE_" string.
@@ -23,11 +23,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     final public const ROLE_ADMIN = 'ROLE_ADMIN';
     final public const ROLE_MODERATOR = 'ROLE_MODERATOR';
     final public const ROLE_SUPER_ADMIN = 'ROLE_SUPER_ADMIN';
-
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private ?int $id = null;
 
     #[ORM\Column(type: Types::STRING)]
     #[Assert\NotBlank]
@@ -147,11 +142,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->documentVotes = new ArrayCollection();
         $this->documentCommentVotes = new ArrayCollection();
         $this->courseCommentVotes = new ArrayCollection();
-    }
-
-    public function getId(): ?int
-    {
-        return $this->id;
     }
 
     public function setFullName(string $fullName): void

--- a/backend/src/Entity/UserDocumentView.php
+++ b/backend/src/Entity/UserDocumentView.php
@@ -10,13 +10,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: UserDocumentViewRepository::class)]
 #[ORM\Index(columns: ['last_viewed'])]
 #[ORM\UniqueConstraint(columns: ['user_id', 'document_id'])]
-class UserDocumentView
+class UserDocumentView extends BaseEntity
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column]
-    private ?int $id = null;
-
     #[ORM\ManyToOne(inversedBy: 'viewedDocuments')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     private User $user;
@@ -33,11 +28,6 @@ class UserDocumentView
         $this->user = $user;
         $this->document = $document;
         $this->lastViewed = $lastViewed;
-    }
-
-    public function getId(): int
-    {
-        return $this->id;
     }
 
     public function getUser(): User

--- a/backend/src/Factory/AnnouncementFactory.php
+++ b/backend/src/Factory/AnnouncementFactory.php
@@ -31,8 +31,8 @@ final class AnnouncementFactory extends PersistentObjectFactory
     #[\Override]
     protected function defaults(): array|callable
     {
-        $createDate = new DateTimeImmutable();
-        $startTime = $createDate->add(new DateInterval('P' . self::faker()->numberBetween(1, 10) . 'D'));
+        $createdAt = new DateTimeImmutable();
+        $startTime = $createdAt->add(new DateInterval('P' . self::faker()->numberBetween(1, 10) . 'D'));
         $endTime = $startTime->add(new DateInterval('P' . self::faker()->numberBetween(1, 10) . 'D'));
         return [
             'title_nl' => self::faker()->word(),

--- a/backend/src/Factory/AnnouncementFactory.php
+++ b/backend/src/Factory/AnnouncementFactory.php
@@ -15,9 +15,7 @@ final class AnnouncementFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     #[\Override]
     public static function class(): string

--- a/backend/src/Factory/CommentCategoryFactory.php
+++ b/backend/src/Factory/CommentCategoryFactory.php
@@ -13,9 +13,7 @@ final class CommentCategoryFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     #[\Override]
     public static function class(): string

--- a/backend/src/Factory/CourseCommentFactory.php
+++ b/backend/src/Factory/CourseCommentFactory.php
@@ -13,9 +13,7 @@ final class CourseCommentFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     #[\Override]
     public static function class(): string

--- a/backend/src/Factory/CourseCommentVoteFactory.php
+++ b/backend/src/Factory/CourseCommentVoteFactory.php
@@ -14,9 +14,7 @@ final class CourseCommentVoteFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     #[\Override]
     public static function class(): string

--- a/backend/src/Factory/CourseFactory.php
+++ b/backend/src/Factory/CourseFactory.php
@@ -62,9 +62,7 @@ final class CourseFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     #[\Override]
     public static function class(): string

--- a/backend/src/Factory/DocumentCategoryFactory.php
+++ b/backend/src/Factory/DocumentCategoryFactory.php
@@ -13,9 +13,7 @@ final class DocumentCategoryFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     #[\Override]
     public static function class(): string

--- a/backend/src/Factory/DocumentCommentFactory.php
+++ b/backend/src/Factory/DocumentCommentFactory.php
@@ -13,9 +13,7 @@ final class DocumentCommentFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     #[\Override]
     public static function class(): string

--- a/backend/src/Factory/DocumentCommentVoteFactory.php
+++ b/backend/src/Factory/DocumentCommentVoteFactory.php
@@ -14,9 +14,7 @@ final class DocumentCommentVoteFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     #[\Override]
     public static function class(): string

--- a/backend/src/Factory/DocumentFactory.php
+++ b/backend/src/Factory/DocumentFactory.php
@@ -13,9 +13,7 @@ final class DocumentFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     #[\Override]
     public static function class(): string

--- a/backend/src/Factory/DocumentVoteFactory.php
+++ b/backend/src/Factory/DocumentVoteFactory.php
@@ -14,9 +14,7 @@ final class DocumentVoteFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     #[\Override]
     public static function class(): string

--- a/backend/src/Factory/ModuleFactory.php
+++ b/backend/src/Factory/ModuleFactory.php
@@ -13,9 +13,7 @@ final class ModuleFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     #[\Override]
     public static function class(): string

--- a/backend/src/Factory/PageFactory.php
+++ b/backend/src/Factory/PageFactory.php
@@ -13,9 +13,7 @@ final class PageFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     #[\Override]
     public static function class(): string

--- a/backend/src/Factory/ProgramFactory.php
+++ b/backend/src/Factory/ProgramFactory.php
@@ -13,9 +13,7 @@ final class ProgramFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     #[\Override]
     public static function class(): string

--- a/backend/src/Factory/QuickLinkFactory.php
+++ b/backend/src/Factory/QuickLinkFactory.php
@@ -13,9 +13,7 @@ final class QuickLinkFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     #[\Override]
     public static function class(): string

--- a/backend/src/Factory/TagFactory.php
+++ b/backend/src/Factory/TagFactory.php
@@ -13,9 +13,7 @@ final class TagFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     #[\Override]
     public static function class(): string

--- a/backend/src/Factory/UserDocumentViewFactory.php
+++ b/backend/src/Factory/UserDocumentViewFactory.php
@@ -13,9 +13,7 @@ final class UserDocumentViewFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     #[\Override]
     public static function class(): string

--- a/backend/src/Factory/UserFactory.php
+++ b/backend/src/Factory/UserFactory.php
@@ -14,9 +14,7 @@ final class UserFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      */
-    public function __construct(private readonly UserPasswordHasherInterface $passwordHasher)
-    {
-    }
+    public function __construct(private readonly UserPasswordHasherInterface $passwordHasher) {}
 
     #[\Override]
     public static function class(): string

--- a/backend/src/Mapper/AnnouncementEntityToApiMapper.php
+++ b/backend/src/Mapper/AnnouncementEntityToApiMapper.php
@@ -49,8 +49,8 @@ class AnnouncementEntityToApiMapper implements MapperInterface
 
         $to->startTime = $from->getStartTime()->format('Y-m-d H:i:s');
         $to->endTime = $from->getEndTime()->format('Y-m-d H:i:s');
-        $to->createdAt = DateTime::createFromInterface($from->getCreateDate())->format('Y-m-d H:i:s');
-        $to->updatedAt = DateTime::createFromInterface($from->getUpdateDate())->format('Y-m-d H:i:s');
+        $to->createdAt = DateTime::createFromInterface($from->getCreatedAt())->format('Y-m-d H:i:s');
+        $to->updatedAt = DateTime::createFromInterface($from->getUpdatedAt())->format('Y-m-d H:i:s');
 
         return $to;
     }

--- a/backend/src/Mapper/AnnouncementEntityToApiMapper.php
+++ b/backend/src/Mapper/AnnouncementEntityToApiMapper.php
@@ -13,8 +13,7 @@ class AnnouncementEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     public function load(object $from, string $toClass, array $context): object
     {

--- a/backend/src/Mapper/AnnouncementEntityToApiMapper.php
+++ b/backend/src/Mapper/AnnouncementEntityToApiMapper.php
@@ -5,13 +5,11 @@ namespace App\Mapper;
 use App\ApiResource\AnnouncementApi;
 use App\ApiResource\UserApi;
 use App\Entity\Announcement;
-use DateTime;
 use Symfonycasts\MicroMapper\AsMapper;
-use Symfonycasts\MicroMapper\MapperInterface;
 use Symfonycasts\MicroMapper\MicroMapperInterface;
 
 #[AsMapper(from: Announcement::class, to: AnnouncementApi::class)]
-class AnnouncementEntityToApiMapper implements MapperInterface
+class AnnouncementEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
@@ -23,7 +21,7 @@ class AnnouncementEntityToApiMapper implements MapperInterface
         assert($from instanceof Announcement);
 
         $dto = new AnnouncementApi();
-        $dto->id = $from->getId();
+        $this->mapBaseFields($from, $dto);
 
         return $dto;
     }
@@ -49,8 +47,6 @@ class AnnouncementEntityToApiMapper implements MapperInterface
 
         $to->startTime = $from->getStartTime()->format('Y-m-d H:i:s');
         $to->endTime = $from->getEndTime()->format('Y-m-d H:i:s');
-        $to->createdAt = DateTime::createFromInterface($from->getCreatedAt())->format('Y-m-d H:i:s');
-        $to->updatedAt = DateTime::createFromInterface($from->getUpdatedAt())->format('Y-m-d H:i:s');
 
         return $to;
     }

--- a/backend/src/Mapper/BaseEntityToApiMapper.php
+++ b/backend/src/Mapper/BaseEntityToApiMapper.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Mapper;
+
+use App\ApiResource\BaseEntityApi;
+use App\Entity\BaseEntity;
+use LogicException;
+use Symfonycasts\MicroMapper\MapperInterface;
+
+/**
+ * Base mapper providing common field mapping for entities extending BaseEntity
+ * and API resources extending BaseEntityApi.
+ *
+ * This mapper handles automatic mapping of id, createdAt, and updatedAt fields.
+ * Extend this class in entity-specific mappers to leverage this functionality.
+ */
+abstract class BaseEntityToApiMapper implements MapperInterface
+{
+    /**
+     * Maps base entity fields (id, createdAt, updatedAt) to the API DTO.
+     * Call this from your mapper's load() method to set up the base fields.
+     *
+     * @param BaseEntity $from The source entity
+     * @param BaseEntityApi $to The target API DTO
+     */
+    protected function mapBaseFields(BaseEntity $from, BaseEntityApi $to): void
+    {
+        $to->id = $from->getId() ?? throw new LogicException('Entity must have an ID before mapping base fields.');
+        $to->createdAt = $from->getCreatedAt()->format(DATE_ATOM);
+        $to->updatedAt = $from->getUpdatedAt()->format(DATE_ATOM);
+    }
+}

--- a/backend/src/Mapper/CommentCategoryApiToEntityMapper.php
+++ b/backend/src/Mapper/CommentCategoryApiToEntityMapper.php
@@ -14,8 +14,7 @@ class CommentCategoryApiToEntityMapper implements MapperInterface
 {
     public function __construct(
         private readonly CommentCategoryRepository $repository,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception

--- a/backend/src/Mapper/CommentCategoryEntityToApiMapper.php
+++ b/backend/src/Mapper/CommentCategoryEntityToApiMapper.php
@@ -5,17 +5,16 @@ namespace App\Mapper;
 use App\ApiResource\CommentCategoryApi;
 use App\Entity\CommentCategory;
 use Symfonycasts\MicroMapper\AsMapper;
-use Symfonycasts\MicroMapper\MapperInterface;
 
 #[AsMapper(from: CommentCategory::class, to: CommentCategoryApi::class)]
-class CommentCategoryEntityToApiMapper implements MapperInterface
+class CommentCategoryEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function load(object $from, string $toClass, array $context): object
     {
         assert($from instanceof CommentCategory);
 
         $dto = new CommentCategoryApi();
-        $dto->id = $from->getId();
+        $this->mapBaseFields($from, $dto);
 
         return $dto;
     }

--- a/backend/src/Mapper/CourseApiToEntityMapper.php
+++ b/backend/src/Mapper/CourseApiToEntityMapper.php
@@ -20,8 +20,7 @@ class CourseApiToEntityMapper implements MapperInterface
         private readonly CourseRepository $repository,
         private readonly MicroMapperInterface $microMapper,
         private readonly PropertyAccessorInterface $propertyAccessor,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception
@@ -56,7 +55,7 @@ class CourseApiToEntityMapper implements MapperInterface
                 $course,
                 Course::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
         }
@@ -68,7 +67,7 @@ class CourseApiToEntityMapper implements MapperInterface
                 $course,
                 Course::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
         }
@@ -80,7 +79,7 @@ class CourseApiToEntityMapper implements MapperInterface
                 $course,
                 Course::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
         }
@@ -92,7 +91,7 @@ class CourseApiToEntityMapper implements MapperInterface
                 $module,
                 Module::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
         }
@@ -104,7 +103,7 @@ class CourseApiToEntityMapper implements MapperInterface
                 $comment,
                 CourseComment::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
         }

--- a/backend/src/Mapper/CourseCommentApiToEntityMapper.php
+++ b/backend/src/Mapper/CourseCommentApiToEntityMapper.php
@@ -21,8 +21,7 @@ class CourseCommentApiToEntityMapper implements MapperInterface
         private readonly CourseCommentRepository $repository,
         private readonly Security $security,
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception
@@ -54,7 +53,7 @@ class CourseCommentApiToEntityMapper implements MapperInterface
                 $from->course,
                 Course::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             )
         );
@@ -63,7 +62,7 @@ class CourseCommentApiToEntityMapper implements MapperInterface
                 $from->category,
                 CommentCategory::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             )
         );

--- a/backend/src/Mapper/CourseCommentEntityToApiMapper.php
+++ b/backend/src/Mapper/CourseCommentEntityToApiMapper.php
@@ -17,8 +17,7 @@ class CourseCommentEntityToApiMapper extends BaseEntityToApiMapper
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
         private readonly Security $security,
-    ) {
-    }
+    ) {}
 
     public function load(object $from, string $toClass, array $context): object
     {

--- a/backend/src/Mapper/CourseCommentEntityToApiMapper.php
+++ b/backend/src/Mapper/CourseCommentEntityToApiMapper.php
@@ -66,8 +66,8 @@ class CourseCommentEntityToApiMapper implements MapperInterface
                 ]
             );
         }
-        $to->createdAt = $from->getCreateDate()->format('Y-m-d H:i:s');
-        $to->updatedAt = $from->getUpdateDate()->format('Y-m-d H:i:s');
+        $to->createdAt = $from->getCreatedAt()->format('Y-m-d H:i:s');
+        $to->updatedAt = $from->getUpdatedAt()->format('Y-m-d H:i:s');
 
         return $to;
     }

--- a/backend/src/Mapper/CourseCommentEntityToApiMapper.php
+++ b/backend/src/Mapper/CourseCommentEntityToApiMapper.php
@@ -9,11 +9,10 @@ use App\ApiResource\UserApi;
 use App\Entity\CourseComment;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfonycasts\MicroMapper\AsMapper;
-use Symfonycasts\MicroMapper\MapperInterface;
 use Symfonycasts\MicroMapper\MicroMapperInterface;
 
 #[AsMapper(from: CourseComment::class, to: CourseCommentApi::class)]
-class CourseCommentEntityToApiMapper implements MapperInterface
+class CourseCommentEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
@@ -26,7 +25,7 @@ class CourseCommentEntityToApiMapper implements MapperInterface
         assert($from instanceof CourseComment);
 
         $dto = new CourseCommentApi();
-        $dto->id = $from->getId();
+        $this->mapBaseFields($from, $dto);
 
         return $dto;
     }
@@ -42,14 +41,14 @@ class CourseCommentEntityToApiMapper implements MapperInterface
             $from->getCourse(),
             CourseApi::class,
             [
-            MicroMapperInterface::MAX_DEPTH => 0,
+                MicroMapperInterface::MAX_DEPTH => 0,
             ]
         );
         $to->category = $this->microMapper->map(
             $from->getCategory(),
             CommentCategoryApi::class,
             [
-            MicroMapperInterface::MAX_DEPTH => 0,
+                MicroMapperInterface::MAX_DEPTH => 0,
             ]
         );
 
@@ -62,13 +61,10 @@ class CourseCommentEntityToApiMapper implements MapperInterface
                 $from->getCreator(),
                 UserApi::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 1,
+                    MicroMapperInterface::MAX_DEPTH => 1,
                 ]
             );
         }
-        $to->createdAt = $from->getCreatedAt()->format('Y-m-d H:i:s');
-        $to->updatedAt = $from->getUpdatedAt()->format('Y-m-d H:i:s');
-
         return $to;
     }
 }

--- a/backend/src/Mapper/CourseCommentVoteApiToEntityMapper.php
+++ b/backend/src/Mapper/CourseCommentVoteApiToEntityMapper.php
@@ -20,8 +20,7 @@ class CourseCommentVoteApiToEntityMapper implements MapperInterface
         private readonly CourseCommentVoteRepository $repository,
         private readonly Security $security,
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception
@@ -52,7 +51,7 @@ class CourseCommentVoteApiToEntityMapper implements MapperInterface
                 $from->courseComment,
                 CourseComment::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             )
         );

--- a/backend/src/Mapper/CourseCommentVoteEntityToApiMapper.php
+++ b/backend/src/Mapper/CourseCommentVoteEntityToApiMapper.php
@@ -48,8 +48,8 @@ class CourseCommentVoteEntityToApiMapper implements MapperInterface
             MicroMapperInterface::MAX_DEPTH => 0,
             ]
         );
-        $to->createdAt = $from->getCreateDate()->format('Y-m-d H:i:s');
-        $to->updatedAt = $from->getUpdateDate()->format('Y-m-d H:i:s');
+        $to->createdAt = $from->getCreatedAt()->format('Y-m-d H:i:s');
+        $to->updatedAt = $from->getUpdatedAt()->format('Y-m-d H:i:s');
 
         return $to;
     }

--- a/backend/src/Mapper/CourseCommentVoteEntityToApiMapper.php
+++ b/backend/src/Mapper/CourseCommentVoteEntityToApiMapper.php
@@ -14,8 +14,7 @@ class CourseCommentVoteEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     public function load(object $from, string $toClass, array $context): object
     {

--- a/backend/src/Mapper/CourseCommentVoteEntityToApiMapper.php
+++ b/backend/src/Mapper/CourseCommentVoteEntityToApiMapper.php
@@ -7,11 +7,10 @@ use App\ApiResource\CourseCommentVoteApi;
 use App\ApiResource\UserApi;
 use App\Entity\CourseCommentVote;
 use Symfonycasts\MicroMapper\AsMapper;
-use Symfonycasts\MicroMapper\MapperInterface;
 use Symfonycasts\MicroMapper\MicroMapperInterface;
 
 #[AsMapper(from: CourseCommentVote::class, to: CourseCommentVoteApi::class)]
-class CourseCommentVoteEntityToApiMapper implements MapperInterface
+class CourseCommentVoteEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
@@ -23,7 +22,7 @@ class CourseCommentVoteEntityToApiMapper implements MapperInterface
         assert($from instanceof CourseCommentVote);
 
         $dto = new CourseCommentVoteApi();
-        $dto->id = $from->getId();
+        $this->mapBaseFields($from, $dto);
 
         return $dto;
     }
@@ -38,19 +37,16 @@ class CourseCommentVoteEntityToApiMapper implements MapperInterface
             $from->getCourseComment(),
             CourseCommentApi::class,
             [
-            MicroMapperInterface::MAX_DEPTH => 0,
+                MicroMapperInterface::MAX_DEPTH => 0,
             ]
         );
         $to->creator = $this->microMapper->map(
             $from->getCreator(),
             UserApi::class,
             [
-            MicroMapperInterface::MAX_DEPTH => 0,
+                MicroMapperInterface::MAX_DEPTH => 0,
             ]
         );
-        $to->createdAt = $from->getCreatedAt()->format('Y-m-d H:i:s');
-        $to->updatedAt = $from->getUpdatedAt()->format('Y-m-d H:i:s');
-
         return $to;
     }
 }

--- a/backend/src/Mapper/CourseEntityToApiMapper.php
+++ b/backend/src/Mapper/CourseEntityToApiMapper.php
@@ -9,11 +9,10 @@ use App\Entity\Course;
 use App\Entity\CourseComment;
 use App\Entity\Module;
 use Symfonycasts\MicroMapper\AsMapper;
-use Symfonycasts\MicroMapper\MapperInterface;
 use Symfonycasts\MicroMapper\MicroMapperInterface;
 
 #[AsMapper(from: Course::class, to: CourseApi::class)]
-class CourseEntityToApiMapper implements MapperInterface
+class CourseEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
@@ -25,7 +24,7 @@ class CourseEntityToApiMapper implements MapperInterface
         assert($from instanceof Course);
 
         $dto = new CourseApi();
-        $dto->id = $from->getId();
+        $this->mapBaseFields($from, $dto);
 
         return $dto;
     }
@@ -47,7 +46,7 @@ class CourseEntityToApiMapper implements MapperInterface
                     $course,
                     CourseApi::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 0,
+                        MicroMapperInterface::MAX_DEPTH => 0,
                     ]
                 );
             },
@@ -59,7 +58,7 @@ class CourseEntityToApiMapper implements MapperInterface
                     $course,
                     CourseApi::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 0,
+                        MicroMapperInterface::MAX_DEPTH => 0,
                     ]
                 );
             },
@@ -72,7 +71,7 @@ class CourseEntityToApiMapper implements MapperInterface
                     $course,
                     CourseApi::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 0,
+                        MicroMapperInterface::MAX_DEPTH => 0,
                     ]
                 );
             },
@@ -85,7 +84,7 @@ class CourseEntityToApiMapper implements MapperInterface
                     $module,
                     ModuleApi::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 0,
+                        MicroMapperInterface::MAX_DEPTH => 0,
                     ]
                 );
             },
@@ -98,7 +97,7 @@ class CourseEntityToApiMapper implements MapperInterface
                     $comment,
                     CourseCommentApi::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 2,
+                        MicroMapperInterface::MAX_DEPTH => 2,
                     ]
                 );
             },

--- a/backend/src/Mapper/CourseEntityToApiMapper.php
+++ b/backend/src/Mapper/CourseEntityToApiMapper.php
@@ -16,8 +16,7 @@ class CourseEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     public function load(object $from, string $toClass, array $context): object
     {

--- a/backend/src/Mapper/DocumentApiToEntityMapper.php
+++ b/backend/src/Mapper/DocumentApiToEntityMapper.php
@@ -21,8 +21,7 @@ class DocumentApiToEntityMapper implements MapperInterface
         private readonly DocumentRepository $repository,
         private readonly Security $security,
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception
@@ -50,7 +49,7 @@ class DocumentApiToEntityMapper implements MapperInterface
                 $from->course,
                 Course::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             )
         );
@@ -59,7 +58,7 @@ class DocumentApiToEntityMapper implements MapperInterface
                 $from->category,
                 DocumentCategory::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             )
         );
@@ -72,7 +71,7 @@ class DocumentApiToEntityMapper implements MapperInterface
                 $tag,
                 Tag::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
             $to->addTag($tagEntity);

--- a/backend/src/Mapper/DocumentCategoryApiToEntityMapper.php
+++ b/backend/src/Mapper/DocumentCategoryApiToEntityMapper.php
@@ -14,8 +14,7 @@ class DocumentCategoryApiToEntityMapper implements MapperInterface
 {
     public function __construct(
         private readonly DocumentCategoryRepository $repository,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception

--- a/backend/src/Mapper/DocumentCategoryEntityToApiMapper.php
+++ b/backend/src/Mapper/DocumentCategoryEntityToApiMapper.php
@@ -5,17 +5,16 @@ namespace App\Mapper;
 use App\ApiResource\DocumentCategoryApi;
 use App\Entity\DocumentCategory;
 use Symfonycasts\MicroMapper\AsMapper;
-use Symfonycasts\MicroMapper\MapperInterface;
 
 #[AsMapper(from: DocumentCategory::class, to: DocumentCategoryApi::class)]
-class DocumentCategoryEntityToApiMapper implements MapperInterface
+class DocumentCategoryEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function load(object $from, string $toClass, array $context): object
     {
         assert($from instanceof DocumentCategory);
 
         $dto = new DocumentCategoryApi();
-        $dto->id = $from->getId();
+        $this->mapBaseFields($from, $dto);
 
         return $dto;
     }

--- a/backend/src/Mapper/DocumentCommentApiToEntityMapper.php
+++ b/backend/src/Mapper/DocumentCommentApiToEntityMapper.php
@@ -20,8 +20,7 @@ class DocumentCommentApiToEntityMapper implements MapperInterface
         private readonly DocumentCommentRepository $repository,
         private readonly Security $security,
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception
@@ -53,7 +52,7 @@ class DocumentCommentApiToEntityMapper implements MapperInterface
                 $from->document,
                 Document::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             )
         );

--- a/backend/src/Mapper/DocumentCommentEntityToApiMapper.php
+++ b/backend/src/Mapper/DocumentCommentEntityToApiMapper.php
@@ -58,8 +58,8 @@ class DocumentCommentEntityToApiMapper implements MapperInterface
                 ]
             );
         }
-        $to->createdAt = $from->getCreateDate()->format('Y-m-d H:i:s');
-        $to->updatedAt = $from->getUpdateDate()->format('Y-m-d H:i:s');
+        $to->createdAt = $from->getCreatedAt()->format('Y-m-d H:i:s');
+        $to->updatedAt = $from->getUpdatedAt()->format('Y-m-d H:i:s');
 
         return $to;
     }

--- a/backend/src/Mapper/DocumentCommentEntityToApiMapper.php
+++ b/backend/src/Mapper/DocumentCommentEntityToApiMapper.php
@@ -8,11 +8,10 @@ use App\ApiResource\UserApi;
 use App\Entity\DocumentComment;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfonycasts\MicroMapper\AsMapper;
-use Symfonycasts\MicroMapper\MapperInterface;
 use Symfonycasts\MicroMapper\MicroMapperInterface;
 
 #[AsMapper(from: DocumentComment::class, to: DocumentCommentApi::class)]
-class DocumentCommentEntityToApiMapper implements MapperInterface
+class DocumentCommentEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
@@ -25,7 +24,7 @@ class DocumentCommentEntityToApiMapper implements MapperInterface
         assert($from instanceof DocumentComment);
 
         $dto = new DocumentCommentApi();
-        $dto->id = $from->getId();
+        $this->mapBaseFields($from, $dto);
 
         return $dto;
     }
@@ -41,7 +40,7 @@ class DocumentCommentEntityToApiMapper implements MapperInterface
             $from->getDocument(),
             DocumentApi::class,
             [
-            MicroMapperInterface::MAX_DEPTH => 0,
+                MicroMapperInterface::MAX_DEPTH => 0,
             ]
         );
 
@@ -54,13 +53,10 @@ class DocumentCommentEntityToApiMapper implements MapperInterface
                 $from->getCreator(),
                 UserApi::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 1,
+                    MicroMapperInterface::MAX_DEPTH => 1,
                 ]
             );
         }
-        $to->createdAt = $from->getCreatedAt()->format('Y-m-d H:i:s');
-        $to->updatedAt = $from->getUpdatedAt()->format('Y-m-d H:i:s');
-
         return $to;
     }
 }

--- a/backend/src/Mapper/DocumentCommentEntityToApiMapper.php
+++ b/backend/src/Mapper/DocumentCommentEntityToApiMapper.php
@@ -16,8 +16,7 @@ class DocumentCommentEntityToApiMapper extends BaseEntityToApiMapper
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
         private readonly Security $security,
-    ) {
-    }
+    ) {}
 
     public function load(object $from, string $toClass, array $context): object
     {

--- a/backend/src/Mapper/DocumentCommentVoteApiToEntityMapper.php
+++ b/backend/src/Mapper/DocumentCommentVoteApiToEntityMapper.php
@@ -20,8 +20,7 @@ class DocumentCommentVoteApiToEntityMapper implements MapperInterface
         private readonly DocumentCommentVoteRepository $repository,
         private readonly Security $security,
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception
@@ -52,7 +51,7 @@ class DocumentCommentVoteApiToEntityMapper implements MapperInterface
                 $from->documentComment,
                 DocumentComment::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             )
         );

--- a/backend/src/Mapper/DocumentCommentVoteEntityToApiMapper.php
+++ b/backend/src/Mapper/DocumentCommentVoteEntityToApiMapper.php
@@ -48,8 +48,8 @@ class DocumentCommentVoteEntityToApiMapper implements MapperInterface
             MicroMapperInterface::MAX_DEPTH => 0,
             ]
         );
-        $to->createdAt = $from->getCreateDate()->format('Y-m-d H:i:s');
-        $to->updatedAt = $from->getUpdateDate()->format('Y-m-d H:i:s');
+        $to->createdAt = $from->getCreatedAt()->format('Y-m-d H:i:s');
+        $to->updatedAt = $from->getUpdatedAt()->format('Y-m-d H:i:s');
 
         return $to;
     }

--- a/backend/src/Mapper/DocumentCommentVoteEntityToApiMapper.php
+++ b/backend/src/Mapper/DocumentCommentVoteEntityToApiMapper.php
@@ -14,8 +14,7 @@ class DocumentCommentVoteEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     public function load(object $from, string $toClass, array $context): object
     {

--- a/backend/src/Mapper/DocumentCommentVoteEntityToApiMapper.php
+++ b/backend/src/Mapper/DocumentCommentVoteEntityToApiMapper.php
@@ -7,11 +7,10 @@ use App\ApiResource\DocumentCommentVoteApi;
 use App\ApiResource\UserApi;
 use App\Entity\DocumentCommentVote;
 use Symfonycasts\MicroMapper\AsMapper;
-use Symfonycasts\MicroMapper\MapperInterface;
 use Symfonycasts\MicroMapper\MicroMapperInterface;
 
 #[AsMapper(from: DocumentCommentVote::class, to: DocumentCommentVoteApi::class)]
-class DocumentCommentVoteEntityToApiMapper implements MapperInterface
+class DocumentCommentVoteEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
@@ -23,7 +22,7 @@ class DocumentCommentVoteEntityToApiMapper implements MapperInterface
         assert($from instanceof DocumentCommentVote);
 
         $dto = new DocumentCommentVoteApi();
-        $dto->id = $from->getId();
+        $this->mapBaseFields($from, $dto);
 
         return $dto;
     }
@@ -38,19 +37,16 @@ class DocumentCommentVoteEntityToApiMapper implements MapperInterface
             $from->getDocumentComment(),
             DocumentCommentApi::class,
             [
-            MicroMapperInterface::MAX_DEPTH => 0,
+                MicroMapperInterface::MAX_DEPTH => 0,
             ]
         );
         $to->creator = $this->microMapper->map(
             $from->getCreator(),
             UserApi::class,
             [
-            MicroMapperInterface::MAX_DEPTH => 0,
+                MicroMapperInterface::MAX_DEPTH => 0,
             ]
         );
-        $to->createdAt = $from->getCreatedAt()->format('Y-m-d H:i:s');
-        $to->updatedAt = $from->getUpdatedAt()->format('Y-m-d H:i:s');
-
         return $to;
     }
 }

--- a/backend/src/Mapper/DocumentEntityToApiMapper.php
+++ b/backend/src/Mapper/DocumentEntityToApiMapper.php
@@ -10,12 +10,11 @@ use App\ApiResource\UserApi;
 use App\Entity\Document;
 use App\Entity\Tag;
 use Symfonycasts\MicroMapper\AsMapper;
-use Symfonycasts\MicroMapper\MapperInterface;
 use Symfonycasts\MicroMapper\MicroMapperInterface;
 use Vich\UploaderBundle\Storage\StorageInterface;
 
 #[AsMapper(from: Document::class, to: DocumentApi::class)]
-class DocumentEntityToApiMapper implements MapperInterface
+class DocumentEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
@@ -28,7 +27,7 @@ class DocumentEntityToApiMapper implements MapperInterface
         assert($from instanceof Document);
 
         $dto = new DocumentApi();
-        $dto->id = $from->getId();
+        $this->mapBaseFields($from, $dto);
 
         return $dto;
     }
@@ -43,15 +42,15 @@ class DocumentEntityToApiMapper implements MapperInterface
             $from->getCourse(),
             CourseApi::class,
             [
-            MicroMapperInterface::MAX_DEPTH => 2,
+                MicroMapperInterface::MAX_DEPTH => 2,
             ]
         );
         $to->category = $this->microMapper->map(
             $from->getCategory(),
             DocumentCategoryApi::class,
             [
-            MicroMapperInterface::MAX_DEPTH => 2,
-            'lang' => isset($context['lang']) ? $context['lang'] : null,
+                MicroMapperInterface::MAX_DEPTH => 2,
+                'lang' => isset($context['lang']) ? $context['lang'] : null,
             ]
         );
         $to->year = $from->getYear();
@@ -61,11 +60,9 @@ class DocumentEntityToApiMapper implements MapperInterface
             $from->getCreator(),
             UserApi::class,
             [
-            MicroMapperInterface::MAX_DEPTH => 1,
+                MicroMapperInterface::MAX_DEPTH => 1,
             ]
         );
-        $to->createdAt = $from->getCreatedAt()->format('Y-m-d H:i:s');
-        $to->updatedAt = $from->getUpdatedAt()->format('Y-m-d H:i:s');
         $to->contentUrl = $this->storage->resolveUri($from, 'file');
         $to->tags = array_map(
             function (Tag $tag) {
@@ -73,7 +70,7 @@ class DocumentEntityToApiMapper implements MapperInterface
                     $tag,
                     TagApi::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 1,
+                        MicroMapperInterface::MAX_DEPTH => 1,
                     ]
                 );
             },

--- a/backend/src/Mapper/DocumentEntityToApiMapper.php
+++ b/backend/src/Mapper/DocumentEntityToApiMapper.php
@@ -64,8 +64,8 @@ class DocumentEntityToApiMapper implements MapperInterface
             MicroMapperInterface::MAX_DEPTH => 1,
             ]
         );
-        $to->createdAt = $from->getCreateDate()->format('Y-m-d H:i:s');
-        $to->updatedAt = $from->getUpdateDate()->format('Y-m-d H:i:s');
+        $to->createdAt = $from->getCreatedAt()->format('Y-m-d H:i:s');
+        $to->updatedAt = $from->getUpdatedAt()->format('Y-m-d H:i:s');
         $to->contentUrl = $this->storage->resolveUri($from, 'file');
         $to->tags = array_map(
             function (Tag $tag) {

--- a/backend/src/Mapper/DocumentEntityToApiMapper.php
+++ b/backend/src/Mapper/DocumentEntityToApiMapper.php
@@ -19,8 +19,7 @@ class DocumentEntityToApiMapper extends BaseEntityToApiMapper
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
         private readonly StorageInterface $storage,
-    ) {
-    }
+    ) {}
 
     public function load(object $from, string $toClass, array $context): object
     {

--- a/backend/src/Mapper/DocumentVoteApiToEntityMapper.php
+++ b/backend/src/Mapper/DocumentVoteApiToEntityMapper.php
@@ -20,8 +20,7 @@ class DocumentVoteApiToEntityMapper implements MapperInterface
         private readonly DocumentVoteRepository $repository,
         private readonly Security $security,
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception
@@ -52,7 +51,7 @@ class DocumentVoteApiToEntityMapper implements MapperInterface
                 $from->document,
                 Document::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             )
         );

--- a/backend/src/Mapper/DocumentVoteEntityToApiMapper.php
+++ b/backend/src/Mapper/DocumentVoteEntityToApiMapper.php
@@ -48,8 +48,8 @@ class DocumentVoteEntityToApiMapper implements MapperInterface
             MicroMapperInterface::MAX_DEPTH => 0,
             ]
         );
-        $to->createdAt = $from->getCreateDate()->format('Y-m-d H:i:s');
-        $to->updatedAt = $from->getUpdateDate()->format('Y-m-d H:i:s');
+        $to->createdAt = $from->getCreatedAt()->format('Y-m-d H:i:s');
+        $to->updatedAt = $from->getUpdatedAt()->format('Y-m-d H:i:s');
 
         return $to;
     }

--- a/backend/src/Mapper/DocumentVoteEntityToApiMapper.php
+++ b/backend/src/Mapper/DocumentVoteEntityToApiMapper.php
@@ -14,8 +14,7 @@ class DocumentVoteEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     public function load(object $from, string $toClass, array $context): object
     {

--- a/backend/src/Mapper/DocumentVoteEntityToApiMapper.php
+++ b/backend/src/Mapper/DocumentVoteEntityToApiMapper.php
@@ -7,11 +7,10 @@ use App\ApiResource\DocumentVoteApi;
 use App\ApiResource\UserApi;
 use App\Entity\DocumentVote;
 use Symfonycasts\MicroMapper\AsMapper;
-use Symfonycasts\MicroMapper\MapperInterface;
 use Symfonycasts\MicroMapper\MicroMapperInterface;
 
 #[AsMapper(from: DocumentVote::class, to: DocumentVoteApi::class)]
-class DocumentVoteEntityToApiMapper implements MapperInterface
+class DocumentVoteEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
@@ -23,7 +22,7 @@ class DocumentVoteEntityToApiMapper implements MapperInterface
         assert($from instanceof DocumentVote);
 
         $dto = new DocumentVoteApi();
-        $dto->id = $from->getId();
+        $this->mapBaseFields($from, $dto);
 
         return $dto;
     }
@@ -38,19 +37,16 @@ class DocumentVoteEntityToApiMapper implements MapperInterface
             $from->getDocument(),
             DocumentApi::class,
             [
-            MicroMapperInterface::MAX_DEPTH => 0,
+                MicroMapperInterface::MAX_DEPTH => 0,
             ]
         );
         $to->creator = $this->microMapper->map(
             $from->getCreator(),
             UserApi::class,
             [
-            MicroMapperInterface::MAX_DEPTH => 0,
+                MicroMapperInterface::MAX_DEPTH => 0,
             ]
         );
-        $to->createdAt = $from->getCreatedAt()->format('Y-m-d H:i:s');
-        $to->updatedAt = $from->getUpdatedAt()->format('Y-m-d H:i:s');
-
         return $to;
     }
 }

--- a/backend/src/Mapper/ModuleApiToEntityMapper.php
+++ b/backend/src/Mapper/ModuleApiToEntityMapper.php
@@ -14,8 +14,7 @@ class ModuleApiToEntityMapper implements MapperInterface
 {
     public function __construct(
         private readonly ModuleRepository $repository,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception

--- a/backend/src/Mapper/ModuleEntityToApiMapper.php
+++ b/backend/src/Mapper/ModuleEntityToApiMapper.php
@@ -15,8 +15,7 @@ class ModuleEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     public function load(object $from, string $toClass, array $context): object
     {

--- a/backend/src/Mapper/ModuleEntityToApiMapper.php
+++ b/backend/src/Mapper/ModuleEntityToApiMapper.php
@@ -8,11 +8,10 @@ use App\ApiResource\ProgramApi;
 use App\Entity\Course;
 use App\Entity\Module;
 use Symfonycasts\MicroMapper\AsMapper;
-use Symfonycasts\MicroMapper\MapperInterface;
 use Symfonycasts\MicroMapper\MicroMapperInterface;
 
 #[AsMapper(from: Module::class, to: ModuleApi::class)]
-class ModuleEntityToApiMapper implements MapperInterface
+class ModuleEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
@@ -24,7 +23,7 @@ class ModuleEntityToApiMapper implements MapperInterface
         assert($from instanceof Module);
 
         $dto = new ModuleApi();
-        $dto->id = $from->getId();
+        $this->mapBaseFields($from, $dto);
 
         return $dto;
     }
@@ -41,7 +40,7 @@ class ModuleEntityToApiMapper implements MapperInterface
                     $course,
                     CourseApi::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 1,
+                        MicroMapperInterface::MAX_DEPTH => 1,
                     ]
                 );
             },
@@ -53,7 +52,7 @@ class ModuleEntityToApiMapper implements MapperInterface
                     $module,
                     ModuleApi::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 1,
+                        MicroMapperInterface::MAX_DEPTH => 1,
                     ]
                 );
             },
@@ -65,7 +64,7 @@ class ModuleEntityToApiMapper implements MapperInterface
                 $from->getProgram(),
                 ProgramApi::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
         }

--- a/backend/src/Mapper/PageEntityToApiMapper.php
+++ b/backend/src/Mapper/PageEntityToApiMapper.php
@@ -5,16 +5,18 @@ namespace App\Mapper;
 use App\ApiResource\PageApi;
 use App\Entity\Page;
 use Symfonycasts\MicroMapper\AsMapper;
-use Symfonycasts\MicroMapper\MapperInterface;
 
 #[AsMapper(from: Page::class, to: PageApi::class)]
-class PageEntityToApiMapper implements MapperInterface
+class PageEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function load(object $from, string $toClass, array $context): object
     {
         assert($from instanceof Page);
 
-        return new PageApi();
+        $dto = new PageApi();
+        $this->mapBaseFields($from, $dto);
+
+        return $dto;
     }
 
     public function populate(object $from, object $to, array $context): object

--- a/backend/src/Mapper/ProgramApiToEntityMapper.php
+++ b/backend/src/Mapper/ProgramApiToEntityMapper.php
@@ -14,8 +14,7 @@ class ProgramApiToEntityMapper implements MapperInterface
 {
     public function __construct(
         private readonly ProgramRepository $repository,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception

--- a/backend/src/Mapper/ProgramEntityToApiMapper.php
+++ b/backend/src/Mapper/ProgramEntityToApiMapper.php
@@ -14,8 +14,7 @@ class ProgramEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     public function load(object $from, string $toClass, array $context): object
     {

--- a/backend/src/Mapper/ProgramEntityToApiMapper.php
+++ b/backend/src/Mapper/ProgramEntityToApiMapper.php
@@ -7,11 +7,10 @@ use App\ApiResource\ProgramApi;
 use App\Entity\Module;
 use App\Entity\Program;
 use Symfonycasts\MicroMapper\AsMapper;
-use Symfonycasts\MicroMapper\MapperInterface;
 use Symfonycasts\MicroMapper\MicroMapperInterface;
 
 #[AsMapper(from: Program::class, to: ProgramApi::class)]
-class ProgramEntityToApiMapper implements MapperInterface
+class ProgramEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
@@ -23,7 +22,7 @@ class ProgramEntityToApiMapper implements MapperInterface
         assert($from instanceof Program);
 
         $dto = new ProgramApi();
-        $dto->id = $from->getId();
+        $this->mapBaseFields($from, $dto);
 
         return $dto;
     }
@@ -41,7 +40,7 @@ class ProgramEntityToApiMapper implements MapperInterface
                     $module,
                     ModuleApi::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 2,
+                        MicroMapperInterface::MAX_DEPTH => 2,
                     ]
                 );
             },

--- a/backend/src/Mapper/QuickLinkEntityToApiMapper.php
+++ b/backend/src/Mapper/QuickLinkEntityToApiMapper.php
@@ -5,17 +5,16 @@ namespace App\Mapper;
 use App\ApiResource\QuickLinkApi;
 use App\Entity\QuickLink;
 use Symfonycasts\MicroMapper\AsMapper;
-use Symfonycasts\MicroMapper\MapperInterface;
 
 #[AsMapper(from: QuickLink::class, to: QuickLinkApi::class)]
-class QuickLinkEntityToApiMapper implements MapperInterface
+class QuickLinkEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function load(object $from, string $toClass, array $context): object
     {
         assert($from instanceof QuickLink);
 
         $dto = new QuickLinkApi();
-        $dto->id = $from->getId();
+        $this->mapBaseFields($from, $dto);
 
         return $dto;
     }

--- a/backend/src/Mapper/TagApiToEntityMapper.php
+++ b/backend/src/Mapper/TagApiToEntityMapper.php
@@ -18,8 +18,7 @@ class TagApiToEntityMapper implements MapperInterface
     public function __construct(
         private readonly TagRepository $repository,
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception
@@ -63,7 +62,7 @@ class TagApiToEntityMapper implements MapperInterface
                 $document,
                 Document::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
             $to->addDocument($documentEntity);

--- a/backend/src/Mapper/TagEntityToApiMapper.php
+++ b/backend/src/Mapper/TagEntityToApiMapper.php
@@ -14,8 +14,7 @@ class TagEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     public function load(object $from, string $toClass, array $context): object
     {

--- a/backend/src/Mapper/TagEntityToApiMapper.php
+++ b/backend/src/Mapper/TagEntityToApiMapper.php
@@ -7,11 +7,10 @@ use App\ApiResource\TagApi;
 use App\Entity\Document;
 use App\Entity\Tag;
 use Symfonycasts\MicroMapper\AsMapper;
-use Symfonycasts\MicroMapper\MapperInterface;
 use Symfonycasts\MicroMapper\MicroMapperInterface;
 
 #[AsMapper(from: Tag::class, to: TagApi::class)]
-class TagEntityToApiMapper implements MapperInterface
+class TagEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
@@ -23,7 +22,7 @@ class TagEntityToApiMapper implements MapperInterface
         assert($from instanceof Tag);
 
         $dto = new TagApi();
-        $dto->id = $from->getId();
+        $this->mapBaseFields($from, $dto);
 
         return $dto;
     }
@@ -40,7 +39,7 @@ class TagEntityToApiMapper implements MapperInterface
                     $document,
                     DocumentApi::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 0,
+                        MicroMapperInterface::MAX_DEPTH => 0,
                     ]
                 );
             },

--- a/backend/src/Mapper/UserApiToEntityMapper.php
+++ b/backend/src/Mapper/UserApiToEntityMapper.php
@@ -22,8 +22,7 @@ class UserApiToEntityMapper implements MapperInterface
         private readonly UserRepository $repository,
         private readonly MicroMapperInterface $microMapper,
         private readonly PropertyAccessorInterface $propertyAccessor,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception
@@ -54,7 +53,7 @@ class UserApiToEntityMapper implements MapperInterface
                 $course,
                 Course::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
         }
@@ -66,7 +65,7 @@ class UserApiToEntityMapper implements MapperInterface
                 $module,
                 Module::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
         }
@@ -78,7 +77,7 @@ class UserApiToEntityMapper implements MapperInterface
                 $program,
                 Program::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
         }
@@ -90,7 +89,7 @@ class UserApiToEntityMapper implements MapperInterface
                 $document,
                 Document::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
         }

--- a/backend/src/Mapper/UserDocumentViewApiToEntityMapper.php
+++ b/backend/src/Mapper/UserDocumentViewApiToEntityMapper.php
@@ -18,8 +18,7 @@ class UserDocumentViewApiToEntityMapper implements MapperInterface
         private readonly UserDocumentViewRepository $repository,
         private readonly Security $security,
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception
@@ -38,7 +37,7 @@ class UserDocumentViewApiToEntityMapper implements MapperInterface
                 $from->document,
                 Document::class,
                 [
-                MicroMapperInterface::MAX_DEPTH => 0,
+                    MicroMapperInterface::MAX_DEPTH => 0,
                 ]
             );
             $user = $this->security->getUser();

--- a/backend/src/Mapper/UserDocumentViewEntityToApiMapper.php
+++ b/backend/src/Mapper/UserDocumentViewEntityToApiMapper.php
@@ -13,8 +13,7 @@ class UserDocumentViewEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     public function load(object $from, string $toClass, array $context): object
     {

--- a/backend/src/Mapper/UserDocumentViewEntityToApiMapper.php
+++ b/backend/src/Mapper/UserDocumentViewEntityToApiMapper.php
@@ -6,11 +6,10 @@ use App\ApiResource\DocumentApi;
 use App\ApiResource\UserDocumentViewApi;
 use App\Entity\UserDocumentView;
 use Symfonycasts\MicroMapper\AsMapper;
-use Symfonycasts\MicroMapper\MapperInterface;
 use Symfonycasts\MicroMapper\MicroMapperInterface;
 
 #[AsMapper(from: UserDocumentView::class, to: UserDocumentViewApi::class)]
-class UserDocumentViewEntityToApiMapper implements MapperInterface
+class UserDocumentViewEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
@@ -22,7 +21,7 @@ class UserDocumentViewEntityToApiMapper implements MapperInterface
         assert($from instanceof UserDocumentView);
 
         $dto = new UserDocumentViewApi();
-        $dto->id = $from->getId();
+        $this->mapBaseFields($from, $dto);
 
         return $dto;
     }
@@ -36,8 +35,8 @@ class UserDocumentViewEntityToApiMapper implements MapperInterface
             $from->getDocument(),
             DocumentApi::class,
             [
-            // Depth: document (0), course (1), course props (2)
-            MicroMapperInterface::MAX_DEPTH => 2,
+                // Depth: document (0), course (1), course props (2)
+                MicroMapperInterface::MAX_DEPTH => 2,
             ]
         );
         $to->lastViewed = $from->getLastViewedAt();

--- a/backend/src/Mapper/UserEntityToApiMapper.php
+++ b/backend/src/Mapper/UserEntityToApiMapper.php
@@ -20,8 +20,7 @@ class UserEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     public function load(object $from, string $toClass, array $context): object
     {

--- a/backend/src/Mapper/UserEntityToApiMapper.php
+++ b/backend/src/Mapper/UserEntityToApiMapper.php
@@ -13,11 +13,10 @@ use App\Entity\Module;
 use App\Entity\Program;
 use App\Entity\User;
 use Symfonycasts\MicroMapper\AsMapper;
-use Symfonycasts\MicroMapper\MapperInterface;
 use Symfonycasts\MicroMapper\MicroMapperInterface;
 
 #[AsMapper(from: User::class, to: UserApi::class)]
-class UserEntityToApiMapper implements MapperInterface
+class UserEntityToApiMapper extends BaseEntityToApiMapper
 {
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
@@ -29,7 +28,7 @@ class UserEntityToApiMapper implements MapperInterface
         assert($from instanceof User);
 
         $dto = new UserApi();
-        $dto->id = $from->getId();
+        $this->mapBaseFields($from, $dto);
 
         return $dto;
     }
@@ -48,7 +47,7 @@ class UserEntityToApiMapper implements MapperInterface
                     $course,
                     CourseApi::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 1,
+                        MicroMapperInterface::MAX_DEPTH => 1,
                     ]
                 );
             },
@@ -60,7 +59,7 @@ class UserEntityToApiMapper implements MapperInterface
                     $module,
                     ModuleApi::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 1,
+                        MicroMapperInterface::MAX_DEPTH => 1,
                     ]
                 );
             },
@@ -72,7 +71,7 @@ class UserEntityToApiMapper implements MapperInterface
                     $program,
                     ProgramApi::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 1,
+                        MicroMapperInterface::MAX_DEPTH => 1,
                     ]
                 );
             },
@@ -84,7 +83,7 @@ class UserEntityToApiMapper implements MapperInterface
                     $document,
                     DocumentApi::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 1,
+                        MicroMapperInterface::MAX_DEPTH => 1,
                     ]
                 );
             },

--- a/backend/src/Pagination/Paginator.php
+++ b/backend/src/Pagination/Paginator.php
@@ -39,8 +39,7 @@ final class Paginator
     public function __construct(
         private readonly DoctrineQueryBuilder $queryBuilder,
         private readonly int $pageSize = self::PAGE_SIZE
-    ) {
-    }
+    ) {}
 
     public function paginate(int $page = 1): self
     {

--- a/backend/src/Repository/CourseCommentVoteRepository.php
+++ b/backend/src/Repository/CourseCommentVoteRepository.php
@@ -47,7 +47,7 @@ class CourseCommentVoteRepository extends ServiceEntityRepository
         return $this->createQueryBuilder('v')
             ->andWhere('v.courseComment = :courseComment')
             ->setParameter('courseComment', $courseComment)
-            ->orderBy('v.createDate', 'DESC')
+            ->orderBy('v.createdAt', 'DESC')
             ->getQuery()
             ->getResult();
     }
@@ -91,7 +91,7 @@ class CourseCommentVoteRepository extends ServiceEntityRepository
         return $this->createQueryBuilder('v')
             ->andWhere('v.creator = :user')
             ->setParameter('user', $user)
-            ->orderBy('v.createDate', 'DESC')
+            ->orderBy('v.createdAt', 'DESC')
             ->getQuery()
             ->getResult();
     }

--- a/backend/src/Repository/DocumentCommentVoteRepository.php
+++ b/backend/src/Repository/DocumentCommentVoteRepository.php
@@ -47,7 +47,7 @@ class DocumentCommentVoteRepository extends ServiceEntityRepository
         return $this->createQueryBuilder('v')
             ->andWhere('v.documentComment = :documentComment')
             ->setParameter('documentComment', $documentComment)
-            ->orderBy('v.createDate', 'DESC')
+            ->orderBy('v.createdAt', 'DESC')
             ->getQuery()
             ->getResult();
     }
@@ -91,7 +91,7 @@ class DocumentCommentVoteRepository extends ServiceEntityRepository
         return $this->createQueryBuilder('v')
             ->andWhere('v.creator = :user')
             ->setParameter('user', $user)
-            ->orderBy('v.createDate', 'DESC')
+            ->orderBy('v.createdAt', 'DESC')
             ->getQuery()
             ->getResult();
     }

--- a/backend/src/Repository/DocumentRepository.php
+++ b/backend/src/Repository/DocumentRepository.php
@@ -97,7 +97,7 @@ class DocumentRepository extends ServiceEntityRepository
 
         /** @var Document[] $result */
         $result = $queryBuilder
-            ->orderBy('d.updateDate', 'DESC')
+            ->orderBy('d.updatedAt', 'DESC')
             ->setMaxResults($limit)
             ->getQuery()
             ->getResult();

--- a/backend/src/Repository/DocumentRepository.php
+++ b/backend/src/Repository/DocumentRepository.php
@@ -54,7 +54,7 @@ class DocumentRepository extends ServiceEntityRepository
             $this->logger->warning(
                 'Error counting pending documents',
                 [
-                'error' => $e->getMessage()
+                    'error' => $e->getMessage()
                 ]
             );
             return 0;

--- a/backend/src/Repository/DocumentVoteRepository.php
+++ b/backend/src/Repository/DocumentVoteRepository.php
@@ -47,7 +47,7 @@ class DocumentVoteRepository extends ServiceEntityRepository
         return $this->createQueryBuilder('v')
             ->andWhere('v.document = :document')
             ->setParameter('document', $document)
-            ->orderBy('v.createDate', 'DESC')
+            ->orderBy('v.createdAt', 'DESC')
             ->getQuery()
             ->getResult();
     }
@@ -91,7 +91,7 @@ class DocumentVoteRepository extends ServiceEntityRepository
         return $this->createQueryBuilder('v')
             ->andWhere('v.creator = :user')
             ->setParameter('user', $user)
-            ->orderBy('v.createDate', 'DESC')
+            ->orderBy('v.createdAt', 'DESC')
             ->getQuery()
             ->getResult();
     }

--- a/backend/src/Security/LitusAuthenticator.php
+++ b/backend/src/Security/LitusAuthenticator.php
@@ -22,8 +22,7 @@ class LitusAuthenticator extends OAuth2Authenticator implements AuthenticationEn
         private readonly ClientRegistry $clientRegistry,
         private readonly RouterInterface $router,
         private readonly UserRepository $userRepository
-    ) {
-    }
+    ) {}
 
     public function start(Request $request, ?AuthenticationException $authException = null): RedirectResponse
     {
@@ -43,7 +42,7 @@ class LitusAuthenticator extends OAuth2Authenticator implements AuthenticationEn
             new UserBadge(
                 $accessToken->getToken(),
                 function () use ($accessToken, $client) {
-                /** @var LitusResourceOwner $litusUser */
+                    /** @var LitusResourceOwner $litusUser */
                     $litusUser = $client->fetchUserFromToken($accessToken);
 
                     return $this->userRepository->createUserfromLitusUser($litusUser, $accessToken);

--- a/backend/src/Security/Voter/AbstractCommentVoter.php
+++ b/backend/src/Security/Voter/AbstractCommentVoter.php
@@ -26,8 +26,7 @@ class AbstractCommentVoter extends Voter
 
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     protected function supports(string $attribute, mixed $subject): bool
     {
@@ -57,7 +56,7 @@ class AbstractCommentVoter extends Voter
                     $subject->creator,
                     User::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 0,
+                        MicroMapperInterface::MAX_DEPTH => 0,
                     ]
                 );
 
@@ -75,7 +74,7 @@ class AbstractCommentVoter extends Voter
                     $subject->creator,
                     User::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 0,
+                        MicroMapperInterface::MAX_DEPTH => 0,
                     ]
                 );
 

--- a/backend/src/Security/Voter/AbstractVoteVoter.php
+++ b/backend/src/Security/Voter/AbstractVoteVoter.php
@@ -17,8 +17,7 @@ class AbstractVoteVoter extends Voter
 
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
 
     protected function supports(string $attribute, mixed $subject): bool
@@ -49,7 +48,7 @@ class AbstractVoteVoter extends Voter
                     $subject->creator,
                     User::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 0,
+                        MicroMapperInterface::MAX_DEPTH => 0,
                     ]
                 );
 
@@ -67,7 +66,7 @@ class AbstractVoteVoter extends Voter
                     $subject->creator,
                     User::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 0,
+                        MicroMapperInterface::MAX_DEPTH => 0,
                     ]
                 );
 

--- a/backend/src/Security/Voter/UserVoter.php
+++ b/backend/src/Security/Voter/UserVoter.php
@@ -21,8 +21,7 @@ class UserVoter extends Voter
 
     public function __construct(
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
 
     protected function supports(string $attribute, mixed $subject): bool
@@ -65,7 +64,7 @@ class UserVoter extends Voter
                     $subject,
                     User::class,
                     [
-                    MicroMapperInterface::MAX_DEPTH => 0,
+                        MicroMapperInterface::MAX_DEPTH => 0,
                     ]
                 );
 

--- a/backend/src/State/EntityClassDtoStateProcessor.php
+++ b/backend/src/State/EntityClassDtoStateProcessor.php
@@ -17,8 +17,7 @@ class EntityClassDtoStateProcessor implements ProcessorInterface
         #[Autowire(service: PersistProcessor::class)] private readonly ProcessorInterface $persistProcessor,
         #[Autowire(service: RemoveProcessor::class)] private readonly ProcessorInterface $removeProcessor,
         private readonly MicroMapperInterface $microMapper
-    ) {
-    }
+    ) {}
 
     /**
      * @param mixed $data

--- a/backend/src/State/EntityClassDtoStateProvider.php
+++ b/backend/src/State/EntityClassDtoStateProvider.php
@@ -2,10 +2,10 @@
 
 namespace App\State;
 
-use ApiPlatform\Doctrine\Orm\State\ItemProvider;
-use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Doctrine\Orm\Paginator;
 use ApiPlatform\Doctrine\Orm\State\CollectionProvider;
+use ApiPlatform\Doctrine\Orm\State\ItemProvider;
+use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\Pagination\TraversablePaginator;
 use ApiPlatform\State\ProviderInterface;
@@ -21,8 +21,7 @@ class EntityClassDtoStateProvider implements ProviderInterface
         #[Autowire(service: ItemProvider::class)] private readonly ProviderInterface $itemProvider,
         private readonly MicroMapperInterface $microMapper,
         private readonly RequestStack $requestStack,
-    ) {
-    }
+    ) {}
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
@@ -30,8 +29,8 @@ class EntityClassDtoStateProvider implements ProviderInterface
         if ($operation instanceof CollectionOperationInterface) {
             $request = $this->requestStack->getCurrentRequest();
             $disablePagination = $request && $request->query->has('pagination') &&
-                                ($request->query->get('pagination') === 'false'
-                                || $request->query->get('pagination') === '0');
+                ($request->query->get('pagination') === 'false'
+                    || $request->query->get('pagination') === '0');
 
             $entities = $this->collectionProvider->provide($operation, $uriVariables, $context);
 

--- a/backend/src/State/PageApiProvider.php
+++ b/backend/src/State/PageApiProvider.php
@@ -3,8 +3,8 @@
 namespace App\State;
 
 use ApiPlatform\Metadata\CollectionOperationInterface;
-use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\PageApi;
 use App\Entity\Page;
 use App\Repository\PageRepository;
@@ -21,8 +21,7 @@ class PageApiProvider implements ProviderInterface
         private readonly PageRepository $pageRepository,
         private readonly MicroMapperInterface $microMapper,
         private readonly RequestStack $requestStack,
-    ) {
-    }
+    ) {}
 
     /*
      * Retrieves a page by unique urlKey and returns the converted PageApi object

--- a/backend/src/State/UserDocumentViewProvider.php
+++ b/backend/src/State/UserDocumentViewProvider.php
@@ -3,14 +3,14 @@
 namespace App\State;
 
 use ApiPlatform\Metadata\CollectionOperationInterface;
-use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\UserDocumentViewApi;
 use App\Entity\User;
 use App\Repository\UserDocumentViewRepository;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfonycasts\MicroMapper\MicroMapperInterface;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfonycasts\MicroMapper\MicroMapperInterface;
 
 /**
  * Custom provider for PageApi because it uses urlKey as identifier, while Page uses id as identifier
@@ -21,8 +21,7 @@ class UserDocumentViewProvider implements ProviderInterface
         private readonly Security $security,
         private readonly UserDocumentViewRepository $viewRepository,
         private readonly MicroMapperInterface $microMapper,
-    ) {
-    }
+    ) {}
 
     public function provide(
         Operation $operation,
@@ -44,8 +43,8 @@ class UserDocumentViewProvider implements ProviderInterface
                         $view,
                         UserDocumentViewApi::class,
                         [
-                        // Depth: document (0), document props (1), course (2), course props (3)
-                        MicroMapperInterface::MAX_DEPTH => 3,
+                            // Depth: document (0), document props (1), course (2), course props (3)
+                            MicroMapperInterface::MAX_DEPTH => 3,
                         ]
                     );
                 },

--- a/backend/tests/Api/CommentCategoryResourceTest.php
+++ b/backend/tests/Api/CommentCategoryResourceTest.php
@@ -24,7 +24,10 @@ class CommentCategoryResourceTest extends ApiTestCase
             ->assertJsonMatches('length("hydra:member")', 5)
             ->json();
 
-        $this->assertSame(array_keys($json->decoded()['hydra:member'][0]), ['@id', '@type', 'name', 'description',]);
+        $this->assertEqualsCanonicalizing(
+            ['@id', '@type', 'name', 'description', 'createdAt', 'updatedAt'],
+            array_keys($json->decoded()['hydra:member'][0])
+        );
     }
 
     public function testGetOneCommentCategory(): void

--- a/backend/tests/Api/CourseCommentResourceTest.php
+++ b/backend/tests/Api/CourseCommentResourceTest.php
@@ -245,6 +245,7 @@ class CourseCommentResourceTest extends ApiTestCase
                         'category' => '/api/comment_categories/' . $category->getId(),
                     ],
                     'headers' => [
+                        'Content-Type' => 'application/ld+json',
                         'Authorization' => 'Bearer ' . $this->token
                     ]
                 ]

--- a/backend/tests/Api/CourseResourceTest.php
+++ b/backend/tests/Api/CourseResourceTest.php
@@ -26,8 +26,7 @@ class CourseResourceTest extends ApiTestCase
             ->assertJsonMatches('length("hydra:member")', 5)
             ->json();
 
-        $this->assertSame(
-            array_keys($json->decoded()['hydra:member'][0]),
+        $this->assertEqualsCanonicalizing(
             [
                 '@id',
                 '@type',
@@ -42,7 +41,10 @@ class CourseResourceTest extends ApiTestCase
                 'newCourses',
                 'modules',
                 'courseComments',
-            ]
+                'createdAt',
+                'updatedAt',
+            ],
+            array_keys($json->decoded()['hydra:member'][0])
         );
     }
 

--- a/backend/tests/Api/DocumentCategoryResourceTest.php
+++ b/backend/tests/Api/DocumentCategoryResourceTest.php
@@ -23,13 +23,15 @@ class DocumentCategoryResourceTest extends ApiTestCase
             ->assertJsonMatches('length("hydra:member")', 5)
             ->json();
 
-        $this->assertSame(
-            array_keys($json->decoded()['hydra:member'][0]),
+        $this->assertEqualsCanonicalizing(
             [
                 '@id',
                 '@type',
                 'name',
-            ]
+                'createdAt',
+                'updatedAt',
+            ],
+            array_keys($json->decoded()['hydra:member'][0])
         );
     }
 

--- a/backend/tests/Api/DocumentResourceTest.php
+++ b/backend/tests/Api/DocumentResourceTest.php
@@ -979,7 +979,6 @@ class DocumentResourceTest extends ApiTestCase
                     ]
                 ]
             )
-            ->dump()
             ->assertStatus(200)
             ->assertJson()
             ->json()->decoded();

--- a/backend/tests/Api/DocumentResourceTest.php
+++ b/backend/tests/Api/DocumentResourceTest.php
@@ -36,8 +36,7 @@ class DocumentResourceTest extends ApiTestCase
             ->assertJsonMatches('length("hydra:member")', 5)
             ->json();
 
-        $this->assertSame(
-            array_keys($json->decoded()['hydra:member'][0]),
+        $this->assertEqualsCanonicalizing(
             [
                 '@id',
                 '@type',
@@ -54,7 +53,8 @@ class DocumentResourceTest extends ApiTestCase
                 'createdAt',
                 'updatedAt',
                 'tags',
-            ]
+            ],
+            array_keys($json->decoded()['hydra:member'][0])
         );
     }
 
@@ -79,8 +79,7 @@ class DocumentResourceTest extends ApiTestCase
             ->assertJsonMatches('"hydra:totalItems"', 5)
             ->assertJsonMatches('length("hydra:member")', 5)
             ->json();
-        $this->assertSame(
-            array_keys($json->decoded()['hydra:member'][0]),
+        $this->assertEqualsCanonicalizing(
             [
                 '@id',
                 '@type',
@@ -96,7 +95,8 @@ class DocumentResourceTest extends ApiTestCase
                 'createdAt',
                 'updatedAt',
                 'tags',
-            ]
+            ],
+            array_keys($json->decoded()['hydra:member'][0])
         ); // Notice that creator is not included in the response.
     }
 
@@ -979,11 +979,18 @@ class DocumentResourceTest extends ApiTestCase
                     ]
                 ]
             )
+            ->dump()
             ->assertStatus(200)
             ->assertJson()
             ->json()->decoded();
 
-        $this->assertContains($documentIRI, $tagResponse['documents']);
+        $documentIRIsinTag = array_map(
+            function ($doc) {
+                return $doc['@id'];
+            },
+            $tagResponse['documents']
+        );
+        $this->assertContains($documentIRI, $documentIRIsinTag);
 
         // Clean up the file
         $contentUrl = $json['contentUrl'];

--- a/backend/tests/Api/ModuleResourceTest.php
+++ b/backend/tests/Api/ModuleResourceTest.php
@@ -31,8 +31,7 @@ class ModuleResourceTest extends ApiTestCase
             ->assertJsonMatches('length("hydra:member")', 5)
             ->json();
 
-        $this->assertSame(
-            array_keys($json->decoded()['hydra:member'][0]),
+        $this->assertEqualsCanonicalizing(
             [
                 '@id',
                 '@type',
@@ -40,7 +39,10 @@ class ModuleResourceTest extends ApiTestCase
                 'courses',
                 'modules',
                 'program',
-            ]
+                'createdAt',
+                'updatedAt',
+            ],
+            array_keys($json->decoded()['hydra:member'][0])
         );
     }
 
@@ -68,15 +70,17 @@ class ModuleResourceTest extends ApiTestCase
             ->assertJsonMatches('length("hydra:member")', 5)
             ->json();
 
-        $this->assertSame(
-            array_keys($json->decoded()['hydra:member'][0]),
+        $this->assertEqualsCanonicalizing(
             [
                 '@id',
                 '@type',
                 'name',
                 'courses',
                 'modules',
-            ]
+                'createdAt',
+                'updatedAt',
+            ],
+            array_keys($json->decoded()['hydra:member'][0])
         );
     }
 
@@ -107,8 +111,11 @@ class ModuleResourceTest extends ApiTestCase
         $parents = array_filter($json->decoded()['hydra:member'], fn($m) => isset($m['modules']) && count($m['modules']) === 2);
         $this->assertCount(3, $parents);
         foreach ($parents as $module) {
+            $this->assertArrayHasKey('modules', $module);
+            $this->assertCount(2, $module['modules']);
             foreach ($module['modules'] as $submodule) {
-                $this->assertIsString($submodule); // Should be IRI string
+                $this->assertArrayHasKey('@id', $submodule);
+                $this->assertArrayHasKey('name', $submodule);
             }
         }
     }

--- a/backend/tests/Api/PageResourceTest.php
+++ b/backend/tests/Api/PageResourceTest.php
@@ -2,9 +2,7 @@
 
 namespace App\Tests\Api;
 
-use App\Entity\Page;
 use App\Factory\PageFactory;
-use Zenstruck\Foundry\Proxy;
 
 class PageResourceTest extends ApiTestCase
 {

--- a/backend/tests/Api/ProgramResourceTest.php
+++ b/backend/tests/Api/ProgramResourceTest.php
@@ -24,14 +24,16 @@ class ProgramResourceTest extends ApiTestCase
             ->assertJsonMatches('length("hydra:member")', 5)
             ->json();
 
-        $this->assertSame(
-            array_keys($json->decoded()['hydra:member'][0]),
+        $this->assertEqualsCanonicalizing(
             [
                 '@id',
                 '@type',
                 'name',
                 'modules',
-            ]
+                'createdAt',
+                'updatedAt',
+            ],
+            array_keys($json->decoded()['hydra:member'][0])
         );
     }
 

--- a/backend/tests/Api/QuickLinkResourceTest.php
+++ b/backend/tests/Api/QuickLinkResourceTest.php
@@ -24,14 +24,16 @@ class QuickLinkResourceTest extends ApiTestCase
             ->assertJsonMatches('length("hydra:member")', 5)
             ->json();
 
-        $this->assertSame(
-            array_keys($json->decoded()['hydra:member'][0]),
+        $this->assertEqualsCanonicalizing(
             [
                 '@id',
                 '@type',
                 'name',
                 'linkTo',
-            ]
+                'createdAt',
+                'updatedAt',
+            ],
+            array_keys($json->decoded()['hydra:member'][0])
         );
     }
 

--- a/backend/tests/Api/TagResourceTest.php
+++ b/backend/tests/Api/TagResourceTest.php
@@ -310,7 +310,7 @@ class TagResourceTest extends ApiTestCase
             ->json()->decoded();
 
         $documentIRIsInResponse = array_map(
-            fn ($doc) => $doc['@id'],
+            fn($doc) => $doc['@id'],
             $response['documents']
         );
         $this->assertContains('/api/documents/' . $document1->getId(), $documentIRIsInResponse);

--- a/backend/tests/Api/TagResourceTest.php
+++ b/backend/tests/Api/TagResourceTest.php
@@ -27,14 +27,16 @@ class TagResourceTest extends ApiTestCase
             ->assertJsonMatches('length("hydra:member")', 5)
             ->json();
 
-        $this->assertSame(
-            array_keys($json->decoded()['hydra:member'][0]),
+        $this->assertEqualsCanonicalizing(
             [
                 '@id',
                 '@type',
                 'name',
                 'documents',
-            ]
+                'createdAt',
+                'updatedAt',
+            ],
+            array_keys($json->decoded()['hydra:member'][0])
         );
     }
 
@@ -307,8 +309,12 @@ class TagResourceTest extends ApiTestCase
             ->assertJsonMatches('length("documents")', 2)
             ->json()->decoded();
 
-        $this->assertContains('/api/documents/' . $document1->getId(), $response['documents']);
-        $this->assertContains('/api/documents/' . $document2->getId(), $response['documents']);
+        $documentIRIsInResponse = array_map(
+            fn ($doc) => $doc['@id'],
+            $response['documents']
+        );
+        $this->assertContains('/api/documents/' . $document1->getId(), $documentIRIsInResponse);
+        $this->assertContains('/api/documents/' . $document2->getId(), $documentIRIsInResponse);
 
         // Verify the relationship from the document side (optional)
         $response = $this->browser()

--- a/backend/tests/Api/UserResourceTest.php
+++ b/backend/tests/Api/UserResourceTest.php
@@ -50,6 +50,8 @@ class UserResourceTest extends ApiTestCase
                 'favoriteModules',
                 'favoritePrograms',
                 'defaultAnonymous',
+                'createdAt',
+                'updatedAt',
             ],
             array_keys($json->decoded())
         );
@@ -74,6 +76,8 @@ class UserResourceTest extends ApiTestCase
                 '@id',
                 '@type',
                 'fullName',
+                'createdAt',
+                'updatedAt',
             ],
             array_keys($json->decoded())
         );
@@ -138,10 +142,10 @@ class UserResourceTest extends ApiTestCase
             ->assertJsonMatches('length(favoriteModules)', 1)
             ->assertJsonMatches('length(favoritePrograms)', 1)
             ->assertJsonMatches('length(favoriteDocuments)', 1)
-            ->assertJsonMatches('favoriteCourses[0]', '/api/courses/' . $course->getId())
-            ->assertJsonMatches('favoriteModules[0]', '/api/modules/' . $module->getId())
-            ->assertJsonMatches('favoritePrograms[0]', '/api/programs/' . $program->getId())
-            ->assertJsonMatches('favoriteDocuments[0]', '/api/documents/' . $document->getId());
+            ->assertJsonMatches('favoriteCourses[0]."@id"', '/api/courses/' . $course->getId())
+            ->assertJsonMatches('favoriteModules[0]."@id"', '/api/modules/' . $module->getId())
+            ->assertJsonMatches('favoritePrograms[0]."@id"', '/api/programs/' . $program->getId())
+            ->assertJsonMatches('favoriteDocuments[0]."@id"', '/api/documents/' . $document->getId());
 
         $this->browser()
             ->get(

--- a/backend/tests/Entity/BaseEntityTest.php
+++ b/backend/tests/Entity/BaseEntityTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\BaseEntity;
+use DateTime;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class BaseEntityTest extends KernelTestCase
+{
+    /**
+     * Create a concrete instance of the abstract BaseEntity class for testing.
+     */
+    private function createBaseEntityInstance(): BaseEntity
+    {
+        return new class extends BaseEntity {
+            // Anonymous class that extends BaseEntity with no additional implementation needed
+        };
+    }
+
+    public function testGetId(): void
+    {
+        $entity = $this->createBaseEntityInstance();
+        $this->assertNull($entity->getId(), 'ID should be null for new entity');
+    }
+
+    public function testOnPrePersist(): void
+    {
+        $entity = $this->createBaseEntityInstance();
+
+        // Before onPrePersist, timestamps are not initialized
+        // onPrePersist sets both createdAt and updatedAt to current time
+        $beforeTime = new DateTime();
+        $entity->onPrePersist();
+        $afterTime = new DateTime();
+
+        // createdAt should be set to current time
+        $this->assertGreaterThanOrEqual($beforeTime, $entity->getCreatedAt());
+        $this->assertLessThanOrEqual($afterTime, $entity->getCreatedAt());
+
+        // updatedAt should equal createdAt
+        $this->assertEquals($entity->getCreatedAt(), $entity->getUpdatedAt());
+    }
+
+    public function testOnPrePersistIdempotent(): void
+    {
+        $entity = $this->createBaseEntityInstance();
+
+        // Call onPrePersist first time
+        $entity->onPrePersist();
+        $firstCreatedAt = $entity->getCreatedAt();
+        $firstUpdatedAt = $entity->getUpdatedAt();
+
+        // Wait a moment
+        sleep(1);
+
+        // Call onPrePersist again - createdAt should not change (null coalescing)
+        $entity->onPrePersist();
+
+        $this->assertEquals($firstCreatedAt, $entity->getCreatedAt(), 'createdAt should not change on subsequent onPrePersist calls');
+        $this->assertEquals($firstUpdatedAt, $entity->getUpdatedAt());
+    }
+
+    public function testOnPreUpdate(): void
+    {
+        $entity = $this->createBaseEntityInstance();
+
+        // Initialize timestamps via onPrePersist
+        $entity->onPrePersist();
+        $originalCreatedAt = $entity->getCreatedAt();
+        $originalUpdatedAt = $entity->getUpdatedAt();
+
+        // Wait a moment to ensure time difference
+        sleep(1);
+
+        // Call onPreUpdate
+        $beforeTime = new DateTime();
+        $entity->onPreUpdate();
+        $afterTime = new DateTime();
+
+        // createdAt should not change on update
+        $this->assertEquals($originalCreatedAt, $entity->getCreatedAt());
+
+        // updatedAt should be updated to a new time
+        $this->assertGreaterThan($originalUpdatedAt, $entity->getUpdatedAt());
+        $this->assertGreaterThanOrEqual($beforeTime, $entity->getUpdatedAt());
+        $this->assertLessThanOrEqual($afterTime, $entity->getUpdatedAt());
+    }
+
+    public function testToString(): void
+    {
+        $entity = $this->createBaseEntityInstance();
+        $stringRepresentation = (string) $entity;
+
+        $this->assertStringContainsString('BaseEntity', $stringRepresentation);
+        $this->assertStringContainsString(' - ', $stringRepresentation);
+    }
+}

--- a/backend/tests/Entity/NodeTest.php
+++ b/backend/tests/Entity/NodeTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Entity;
 
+use App\Entity\BaseEntity;
 use App\Entity\Node;
 use App\Entity\User;
 use DateTime;
@@ -19,38 +20,50 @@ class NodeTest extends KernelTestCase
         };
     }
 
-    public function testConstructNode()
-    {
-        $creator = $this->createStub(User::class);
-        $beforedate = new DateTime();
-        $node = $this->createNodeInstance($creator);
-        $afterdate = new DateTime();
-        $this->assertGreaterThanOrEqual($beforedate, $node->getCreateDate(), 'The createDate should be set to the current date');
-        $this->assertLessThanOrEqual($afterdate, $node->getCreateDate());
-    }
-
-    public function testSetUpdate()
+    public function testConstructNode(): void
     {
         $creator = $this->createStub(User::class);
         $node = $this->createNodeInstance($creator);
 
-        $beforedate = new DateTime();
-        $node->setUpdateDate();
-        $afterdate = new DateTime();
-
-        $this->assertGreaterThanOrEqual($beforedate, $node->getUpdateDate(), 'The updateDate should be set to the current date');
-        $this->assertLessThanOrEqual($afterdate, $node->getUpdateDate());
+        // Node constructor sets creator but does not initialize timestamps
+        // Timestamps are initialized via Doctrine lifecycle callbacks (onPrePersist)
+        $this->assertSame($creator, $node->getCreator());
     }
 
-    public function testSetUser()
+    public function testTimestampsInitializedByPrePersist(): void
+    {
+        $creator = $this->createStub(User::class);
+        $node = $this->createNodeInstance($creator);
+
+        // Simulate Doctrine's onPrePersist lifecycle event
+        $beforeTime = new DateTime();
+        $node->onPrePersist();
+        $afterTime = new DateTime();
+
+        // Verify timestamps are now set
+        $this->assertGreaterThanOrEqual($beforeTime, $node->getCreatedAt());
+        $this->assertLessThanOrEqual($afterTime, $node->getCreatedAt());
+        $this->assertGreaterThanOrEqual($beforeTime, $node->getUpdatedAt());
+        $this->assertLessThanOrEqual($afterTime, $node->getUpdatedAt());
+    }
+
+    public function testGetCreator(): void
     {
         $creator = $this->createStub(User::class);
         $node = $this->createNodeInstance($creator);
 
         $this->assertSame($creator, $node->getCreator());
+    }
 
-        $user = $this->createStub(User::class);
-        $node->setCreator($user);
-        $this->assertSame($user, $node->getCreator());
+    public function testSetCreator(): void
+    {
+        $creator = $this->createStub(User::class);
+        $node = $this->createNodeInstance($creator);
+
+        $newCreator = $this->createStub(User::class);
+        $returnedNode = $node->setCreator($newCreator);
+
+        $this->assertSame($newCreator, $node->getCreator());
+        $this->assertSame($node, $returnedNode, 'setCreator should return self for fluent interface');
     }
 }

--- a/backend/tests/Entity/NodeTest.php
+++ b/backend/tests/Entity/NodeTest.php
@@ -2,7 +2,6 @@
 
 namespace App\Tests\Entity;
 
-use App\Entity\BaseEntity;
 use App\Entity\Node;
 use App\Entity\User;
 use DateTime;

--- a/frontend/src/types/entities.ts
+++ b/frontend/src/types/entities.ts
@@ -1,12 +1,12 @@
 import { VoteDirection } from "@/components/ui/buttons/VoteButton";
 interface BaseEntity {
     id: number;
+    createdAt?: Date;
+    updatedAt?: Date;
 }
 
 interface NodeEntity extends BaseEntity {
-    creator?: User,
-    createdAt?: Date;
-    updatedAt?: Date;
+    creator?: User;
 }
 
 export interface Course extends BaseEntity {


### PR DESCRIPTION
This pull request introduces a new migration to standardize timestamp fields across multiple database tables and refactors several API resource DTOs to use consistent serialization groups and base classes. The main focus is on improving consistency and maintainability in both the database schema and API responses.

Key changes include:

**Database Schema Standardization:**

* Introduced a migration that replaces all `create_date`/`update_date` columns with standardized `created_at`/`updated_at` columns across multiple tables. Existing data is migrated, and the migration is fully reversible.

**API Resource Refactoring:**

* Added a new abstract base class `BaseEntityApi` that provides common fields (`id`, `createdAt`, `updatedAt`) and ensures these are included in a shared serialization group for all API resources.
* Updated `AnnouncementApi` and `CommentCategoryApi` to extend from their respective base classes (`NodeApi` and `BaseEntityApi`), and to use serialization groups from a new `SerializationGroups` constants class for more maintainable and consistent group assignments. [[1]](diffhunk://#diff-efed9d5f71acc9a6c761efdca7a258e5ebda7c645c678dfeaffe65cac64f498cR14-R19) [[2]](diffhunk://#diff-efed9d5f71acc9a6c761efdca7a258e5ebda7c645c678dfeaffe65cac64f498cL37-R40) [[3]](diffhunk://#diff-efed9d5f71acc9a6c761efdca7a258e5ebda7c645c678dfeaffe65cac64f498cL56-R75) [[4]](diffhunk://#diff-efed9d5f71acc9a6c761efdca7a258e5ebda7c645c678dfeaffe65cac64f498cR84-R99) [[5]](diffhunk://#diff-db63ea52f320a5af3a605957f7593ea7942bf52f877ef00b752a96f5580d0072L7-R15) [[6]](diffhunk://#diff-db63ea52f320a5af3a605957f7593ea7942bf52f877ef00b752a96f5580d0072R24-R38) [[7]](diffhunk://#diff-db63ea52f320a5af3a605957f7593ea7942bf52f877ef00b752a96f5580d0072R47)
* Updated `AbstractCommentApi` and `AbstractVoteApi` to use the new `SerializationGroups` constants for group assignments, and expanded group usage for more granular control over serialization. [[1]](diffhunk://#diff-496f26def6edf48b82eff4b4fe0710576a842253f9f672a307919dc513a48a70R8-R32) [[2]](diffhunk://#diff-33a5b72f3c79ef50a198d1d26fb6d600a6dc506e82cbcf50b1f89dd613c7a69dL7-R20)
* Added normalization contexts to API resources to ensure the correct serialization groups are always applied. [[1]](diffhunk://#diff-efed9d5f71acc9a6c761efdca7a258e5ebda7c645c678dfeaffe65cac64f498cL37-R40) [[2]](diffhunk://#diff-efed9d5f71acc9a6c761efdca7a258e5ebda7c645c678dfeaffe65cac64f498cL56-R75) [[3]](diffhunk://#diff-db63ea52f320a5af3a605957f7593ea7942bf52f877ef00b752a96f5580d0072R24-R38)

These changes collectively improve the consistency, maintainability, and clarity of both the database schema and the API layer.