### PR TITLE
fix: sentry setup in backend and frontend

### DIFF
--- a/.docker/docker-compose.prod.yml
+++ b/.docker/docker-compose.prod.yml
@@ -81,9 +81,6 @@ services:
       - ${DATA_DIR:?DATA_DIR is required}:/app/data
       # JWT directory - where JWT keys are stored
       - ${JWT_DIR:?JWT_DIR is required}:/app/config/jwt
-      # Var directory for cache and logs
-      # Using named volume for better performance
-      - backend_var:/app/var
 
     # Health check to ensure backend is ready before frontend starts
     healthcheck:
@@ -121,15 +118,6 @@ services:
     # Port mapping - only expose internally to nginx
     expose:
       - "3000"
-
-    # Environment variables
-    environment:
-      # File upload configuration
-      NEXT_PUBLIC_MAX_FILE_SIZE_MB: "200"
-      NEXT_PUBLIC_ALLOWED_MIME_TYPES: "application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/msword,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.text,application/vnd.oasis.opendocument.spreadsheet,application/vnd.oasis.opendocument.presentation,image/jpeg,image/jpg,image/png,image/svg+xml,image/gif,application/zip,text/csv,text/plain,text/markdown,text/x-matlab,text/x-python,video/mp4"
-
-      # Sentry configuration
-      NEXT_PUBLIC_SENTRY_DSN: ${SENTRY_DSN:-}
 
     depends_on:
       backend:
@@ -188,7 +176,3 @@ services:
         max-size: "50m" # Rotate when file reaches 50MB
         max-file: "5" # Keep 5 rotated files (250MB total per service)
         compress: "true" # Compress rotated logs to save space
-
-volumes:
-  backend_var:
-    driver: local

--- a/.github/workflows/build-backend.yaml
+++ b/.github/workflows/build-backend.yaml
@@ -71,3 +71,8 @@ jobs:
             COMMIT_HASH=${{ github.sha }}
             VERSION=${{ (github.ref_type == 'tag' && github.ref_name) || '' }}
             # VERSION is only set for tag releases, empty string for branch deployments
+            # Sentry release: git tag on production releases, commit SHA on dev deploys.
+            # Environment is the deploy stage (dev/production) so dev-server and prod-server
+            # errors are distinguishable.
+            SENTRY_RELEASE=${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
+            SENTRY_ENVIRONMENT=${{ inputs.environment }}

--- a/.github/workflows/build-frontend.yaml
+++ b/.github/workflows/build-frontend.yaml
@@ -66,6 +66,15 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/${{ steps.repo_name.outputs.lowercase }}/frontend:buildcache
           cache-to: type=registry,ref=ghcr.io/${{ steps.repo_name.outputs.lowercase }}/frontend:buildcache,mode=max
           build-args: |
-            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             NEXT_PUBLIC_FRONTEND_URL=${{ inputs.url }}
             NEXT_PUBLIC_BACKEND_URL=${{ inputs.url }}
+            NEXT_PUBLIC_SENTRY_DSN=${{ secrets.SENTRY_DSN }}
+            # Sentry release: git tag on production releases, commit SHA on dev deploys.
+            # The Next.js plugin tags events and uploads source maps under it. Environment
+            # is the deploy stage (dev/production); NEXT_PUBLIC_ so it's inlined client-side.
+            SENTRY_RELEASE=${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
+            NEXT_PUBLIC_SENTRY_ENVIRONMENT=${{ inputs.environment }}
+          # Secret (source-map upload) passed via BuildKit secret mount, not a build-arg,
+          # so it never lands in image layers or the registry build cache.
+          secrets: |
+            sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -146,3 +146,31 @@ jobs:
             echo "Cleaning up old images..."
             docker image prune -a -f
           EOF
+
+  sentry_release:
+    name: Sentry Release
+    runs-on: ubuntu-latest
+    needs: [deploy]
+    environment:
+      name: ${{ inputs.environment }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Full history so Sentry can associate commits with the release.
+          fetch-depth: 0
+
+      - name: Create Sentry release
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: vtko-vzw
+          SENTRY_PROJECT: burgieclan
+        with:
+          release: ${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
+          environment: ${{ inputs.environment }}
+          set_commits: auto
+          # Don't fail the deploy if commit association hits a missing ref (force-push/
+          # rebase) or finds no new commits (e.g. first release / re-deploy).
+          ignore_missing: true
+          ignore_empty: true

--- a/backend/.docker/production/Dockerfile
+++ b/backend/.docker/production/Dockerfile
@@ -35,8 +35,6 @@ WORKDIR /app
 # These folders are defined as volumes to ensure they use external persistence
 # (as configured in docker-compose) rather than being part of the image layers.
 # This is crucial for runtime data and external configuration mounts.
-# Logs and Cache. Persisted via the 'backend_var' named volume in Compose.
-VOLUME /app/var/
 # Application data/uploads. Mounted from the host via ${DATA_DIR} in Compose.
 VOLUME /app/data
 # Sensitive JWT keys. Mounted from the host via ${JWT_DIR} in Compose.
@@ -98,11 +96,15 @@ ARG FRONTEND_URL
 ARG APP_ENV=prod
 ARG COMMIT_HASH
 ARG VERSION
+ARG SENTRY_RELEASE
+ARG SENTRY_ENVIRONMENT
 
 ENV APP_ENV=$APP_ENV
 ENV FRONTEND_URL=$FRONTEND_URL
 ENV COMMIT_HASH=$COMMIT_HASH
 ENV VERSION=$VERSION
+ENV SENTRY_RELEASE=$SENTRY_RELEASE
+ENV SENTRY_ENVIRONMENT=$SENTRY_ENVIRONMENT
 ENV JWT_PUBLIC_KEY=/app/config/jwt/public.pem
 ENV JWT_SECRET_KEY=/app/config/jwt/private.pem
 

--- a/backend/config/packages/sentry.yaml
+++ b/backend/config/packages/sentry.yaml
@@ -7,14 +7,17 @@ when@prod:
         tracing:
             enabled: false
 
-        # If you are using Monolog, you also need this additional configuration to log the errors correctly:
-        # https://docs.sentry.io/platforms/php/guides/symfony/#monolog-integration
-        register_error_listener: false
+        # Capture unhandled exceptions as Sentry issues. The Monolog handler below
+        # feeds Sentry Logs (a separate product), so the two are complementary.
+        register_error_listener: true
+        # Left off to avoid reporting PHP deprecations as issues.
         register_error_handler: false
 
         options:
-            # Set custom Sentry environment
-            environment: "backend-%kernel.environment%"
+            environment: "%env(default::SENTRY_ENVIRONMENT)%"
+            release: "%env(default::SENTRY_RELEASE)%"
+            tags:
+                component: backend
             # Required for LogsHandler (Sentry Logs API)
             enable_logs: true
             # Ignore 404 errors

--- a/frontend/.docker/production/Dockerfile
+++ b/frontend/.docker/production/Dockerfile
@@ -1,3 +1,7 @@
+# syntax=docker/dockerfile:1
+# ^ Selects the BuildKit Dockerfile frontend so `RUN --mount=type=secret` (used below for
+#   the Sentry auth token) works consistently across Docker installs / CI runners.
+
 # Stage 1: Dependencies
 FROM node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS base
 
@@ -15,18 +19,19 @@ RUN npm ci --no-audit
 FROM base AS builder
 WORKDIR /app
 
-# Accept Sentry auth token as secret for build-time use
-# This is used to upload source maps to Sentry during build
-# Note: Using ARG is acceptable here since the token is only needed during build
-# and is not persisted in the final image layers
-ARG SENTRY_AUTH_TOKEN
-
-# Accept Next.js public environment variables as build args
-# These are embedded at build time, not runtime
+# Next.js public env vars: inlined into the bundle at BUILD time, so they must be set here
+# (a runtime value is ignored). NEXT_PUBLIC_SENTRY_DSN missing => client Sentry disabled.
 ARG NEXT_PUBLIC_FRONTEND_URL
 ARG NEXT_PUBLIC_BACKEND_URL
+ARG NEXT_PUBLIC_SENTRY_DSN
+ARG NEXT_PUBLIC_SENTRY_ENVIRONMENT
 ENV NEXT_PUBLIC_FRONTEND_URL=$NEXT_PUBLIC_FRONTEND_URL
 ENV NEXT_PUBLIC_BACKEND_URL=$NEXT_PUBLIC_BACKEND_URL
+ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
+ENV NEXT_PUBLIC_SENTRY_ENVIRONMENT=$NEXT_PUBLIC_SENTRY_ENVIRONMENT
+
+ARG SENTRY_RELEASE
+ENV SENTRY_RELEASE=$SENTRY_RELEASE
 
 # Copy dependencies from deps stage
 COPY --from=deps /app/node_modules ./node_modules
@@ -37,8 +42,15 @@ COPY . .
 # Set environment variables for build
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Build the application
-RUN npm run build
+# Build the application.
+# SENTRY_AUTH_TOKEN (used by the Sentry Next.js plugin to upload source maps) is a real
+# secret, so it's provided via a BuildKit secret mount rather than ARG/ENV. This keeps it
+# out of image layers AND out of the registry build cache (cache-to mode=max). The token
+# is exposed only as an env var for the duration of this single RUN; if absent (e.g. local
+# builds), the Sentry plugin simply skips the upload.
+RUN --mount=type=secret,id=sentry_auth_token \
+    export SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token 2>/dev/null || true)" && \
+    npm run build
 
 # Stage 3: Runner
 FROM base AS runner

--- a/frontend/.env.dist
+++ b/frontend/.env.dist
@@ -6,9 +6,5 @@ NEXT_PUBLIC_BACKEND_URL="http://localhost:8000"
 SENTRY_AUTH_TOKEN="sentryauthtoken"
 NEXT_PUBLIC_SENTRY_DSN="https://f53a49503225bec48937f7a8288bf80f@o918793.ingest.us.sentry.io/4506733883621376"
 
-### File Upload
-NEXT_PUBLIC_MAX_FILE_SIZE_MB="10"
-NEXT_PUBLIC_ALLOWED_MIME_TYPES="application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/msword,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.text,application/vnd.oasis.opendocument.spreadsheet,application/vnd.oasis.opendocument.presentation,image/jpeg,image/jpg,image/png,image/svg+xml,image/gif,application/zip,text/csv,text/plain,text/markdown,text/x-matlab,text/x-python,video/mp4"
-
 ### Telemetry
 NEXT_TELEMETRY_DISABLED=1

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,9 @@
 import { withSentryConfig } from '@sentry/nextjs';
+import type { NextConfig } from 'next';
+// Single source of truth for the upload size limit (see src/utils/constants/upload.ts).
+import { FILE_SIZE_MB } from './src/utils/constants/upload';
 
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const nextConfig: NextConfig = {
     output: 'standalone',
     reactStrictMode: false,
     images: {
@@ -22,7 +24,8 @@ const nextConfig = {
     },
     experimental: {
         serverActions: {
-            bodySizeLimit: `${parseInt(process.env.NEXT_PUBLIC_MAX_FILE_SIZE_MB ?? '10') + 5}mb`,
+            // +5 MB headroom over the file limit for multipart/form-data overhead.
+            bodySizeLimit: `${FILE_SIZE_MB + 5}mb`,
         },
     },
 };
@@ -33,6 +36,10 @@ export default withSentryConfig(nextConfig, {
 
     org: "vtko-vzw",
     project: "burgieclan",
+
+    release: {
+        name: process.env.SENTRY_RELEASE || undefined,
+    },
 
     // Pass the auth token
     authToken: process.env.SENTRY_AUTH_TOKEN,

--- a/frontend/sentry.edge.config.ts
+++ b/frontend/sentry.edge.config.ts
@@ -9,7 +9,9 @@ import { captureConsoleIntegration, init } from "@sentry/nextjs";
 init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
-  environment: "frontend-" + process.env.NODE_ENV,
+  environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || "development",
+
+  initialScope: { tags: { component: "frontend" } },
   integrations: [captureConsoleIntegration({ levels: ["error", "warn", "log"] })],
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -7,8 +7,10 @@ import { captureConsoleIntegration, init } from "@sentry/nextjs";
 
 init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  
-  environment: "frontend-" + process.env.NODE_ENV,
+
+  environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || "development",
+
+  initialScope: { tags: { component: "frontend" } },
   integrations: [captureConsoleIntegration({ levels: ["error", "warn", "log"] })],
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.

--- a/frontend/src/instrumentation-client.ts
+++ b/frontend/src/instrumentation-client.ts
@@ -8,7 +8,9 @@ import { captureConsoleIntegration, captureRouterTransitionStart, init, replayIn
 init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
-  environment: "frontend-" + process.env.NODE_ENV,
+  environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || "development",
+
+  initialScope: { tags: { component: "frontend" } },
 
   // Add optional integrations for additional features
   integrations: [

--- a/frontend/src/utils/constants/upload.ts
+++ b/frontend/src/utils/constants/upload.ts
@@ -1,24 +1,31 @@
-const DEFAULT_MIME_TYPES = [
+// Upload limits are hardcoded: they're identical across environments, and a NEXT_PUBLIC_
+// env var would be inlined at build time anyway — so the env indirection only created the
+// illusion of runtime configurability. Change these values here.
+export const ALLOWED_MIME_TYPES = [
     'application/pdf',
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
     'application/msword',
-    'text/plain',
+    'application/vnd.ms-powerpoint',
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/vnd.oasis.opendocument.text',
+    'application/vnd.oasis.opendocument.spreadsheet',
+    'application/vnd.oasis.opendocument.presentation',
     'image/jpeg',
+    'image/jpg',
     'image/png',
-    'video/mp4',
+    'image/svg+xml',
+    'image/gif',
     'application/zip',
+    'text/csv',
+    'text/plain',
+    'text/markdown',
     'text/x-matlab',
-    'text/x-python'
+    'text/x-python',
+    'video/mp4'
 ] as const;
 
-const parseAllowedMimeTypes = (): readonly string[] => {
-    const envMimeTypes = process.env.NEXT_PUBLIC_ALLOWED_MIME_TYPES?.split(',');
-    return envMimeTypes ?? DEFAULT_MIME_TYPES;
-};
-
-export const ALLOWED_MIME_TYPES = parseAllowedMimeTypes();
-
-export const FILE_SIZE_MB = parseInt(process.env.NEXT_PUBLIC_MAX_FILE_SIZE_MB ?? '10');
+export const FILE_SIZE_MB = 200;
 export const FILE_SIZE_LIMIT = FILE_SIZE_MB * 1024 * 1024;
 
 export const VISIBLE_YEARS = 5;


### PR DESCRIPTION
## Why

Sentry was configured but not actually working end-to-end, and a few related infra rough edges had built up alongside it:

- **Client-side error reporting was silently dead.** The browser DSN (`NEXT_PUBLIC_SENTRY_DSN`) was only injected at *runtime* via `docker-compose`. But Next.js inlines `NEXT_PUBLIC_*` vars into the bundle at *build time*, so the shipped frontend had no DSN — the browser SDK initialised against `undefined` and reported nothing. No runtime value could ever fix that.
- **Backend errors never became issues.** `register_error_listener` was off and the only Monolog handler wired was the *Logs* handler, so unhandled exceptions produced neither a Sentry issue nor a usable signal. A real outage could (and did) page nobody.
- **Stack traces were unreadable and unattributable.** No release was associated with a build, and source maps weren't tied to one, so production errors showed minified frames and couldn't be linked to the commit that caused them.
- **Environments conflated build-mode with deploy-stage.** Events were tagged `frontend-production` / `backend-prod`, derived from `NODE_ENV` / `kernel.environment` — both of which are "prod" on the dev server too (it runs a production build). So dev and prod errors were indistinguishable.
- **The auth token leaked into image layers.** `SENTRY_AUTH_TOKEN` was a Docker `ARG`, which persists in build history and the `mode=max` registry build cache.
- **A persisted cache volume could outlive a deploy**, and the upload limits were configured in a way that never actually took effect.

## What changed

### Sentry actually reports now
- **Frontend:** `NEXT_PUBLIC_SENTRY_DSN` is passed as a **build arg** so it's inlined into the client bundle — the browser SDK finally has a DSN and reports.
- **Backend:** `register_error_listener` is turned **on**, so unhandled exceptions are captured as Sentry *issues*. The Monolog `LogsHandler` keeps feeding Sentry *Logs* (a separate product), so the two are complementary, not duplicates. `register_error_handler` stays **off** on purpose — it would otherwise turn PHP deprecation notices into issues and bury the real signal.

### Releases, source maps & commit attribution
- One release identifier is used everywhere: the **git tag** on production (release) deploys, the **commit SHA** on dev (branch) deploys.
- It's threaded into both image builds as `SENTRY_RELEASE`, so backend and frontend events all carry the same release, and the Next.js Sentry plugin uploads **source maps under that release** (readable prod stack traces).
- A new **`sentry_release` job** in `deploy.yaml` runs after a successful deploy, creates the release object, and associates commits (`set_commits: auto` over full git history) so an issue points back to the suspect commit. It's resilient by design (`ignore_missing` / `ignore_empty`) so a force-push, first release, or no-op redeploy never blocks a deploy. The action is pinned to a digest (`getsentry/action-release@ff07929… # v3.7.0`).

### Environment = deploy stage; app = a tag
- `environment` is now the **deploy stage** (`dev` / `production`), injected from the pipeline (`SENTRY_ENVIRONMENT` / `NEXT_PUBLIC_SENTRY_ENVIRONMENT = inputs.environment`) instead of derived from `NODE_ENV` / `kernel.environment`. Dev-server and prod-server errors are now distinguishable, and the SDK environments line up with the release job's deploy marker.
- Every event carries a `component: backend` / `component: frontend` tag, so the **single Sentry project** cleanly separates the two halves (filter / alert / dashboard by `component`).

### Auth token no longer leaks
- `SENTRY_AUTH_TOKEN` moves from a build `ARG` to a **BuildKit secret mount** (`--mount=type=secret`), exposed only for the `npm run build` step. It never lands in image layers or the registry build cache. If absent (e.g. local builds), source-map upload is simply skipped.

### Upload config: one source of truth, no fake knobs
- `NEXT_PUBLIC_MAX_FILE_SIZE_MB` / `NEXT_PUBLIC_ALLOWED_MIME_TYPES` are removed. They *looked* runtime-configurable but, being `NEXT_PUBLIC_`, were inlined at build — and weren't even passed as build args, so production silently ran on the fallback defaults (10 MB + a short MIME list) regardless of what `docker-compose` claimed.
- The limits now live directly in `src/utils/constants/upload.ts` (raised to the intended 200 MB and the full MIME list).
- `next.config.mjs` → **`next.config.ts`** so it can `import { FILE_SIZE_MB }` and derive the server-action `bodySizeLimit` (`FILE_SIZE_MB + 5` MB headroom). Client validation, the server-action body cap, and UI labels can no longer drift apart.

### Backend `var` volume removed
- Dropped the `backend_var` named volume and `VOLUME /app/var/`. Logs already stream to `stderr` (captured by the json-file logging driver with rotation) and the cache is regenerated on boot, so persisting `/app/var` bought nothing and risked a **stale cache surviving across deploys** — the failure mode that breaks the app after a dependency/framework upgrade. Cache is now ephemeral and rebuilt per image.

## Risk / scope
Configuration and infrastructure only — no application logic changed. No remaining references to the removed env vars; the upload constants are still exported and consumed everywhere; `next.config.ts` typechecks against the imported constant.

### Required for this to take effect in a deployed env
- Add **`SENTRY_DSN`** as a GitHub environment secret (dev + production) — it feeds the frontend build arg. Backend reads its DSN from the server `.env` at runtime (unchanged).
- Ensure **`SENTRY_AUTH_TOKEN`** exists as an environment secret (used by the build's source-map upload and the release job).
