### PR TITLE
fix: use npm self-reference for postcss override

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
     "typescript": "6.0.3"
   },
   "overrides": {
-    "postcss": "^8.5.23",
+    "postcss": "$postcss",
     "sharp": "$sharp",
     "brace-expansion": "^5.0.8",
     "minimatch": "^10.0.3"


### PR DESCRIPTION
## Problem

`frontend/package.json` lists `postcss` both as a direct devDependency and as an `overrides` entry, with the same spec:

```json
"devDependencies": { "postcss": "^8.5.23" },
"overrides":       { "postcss": "^8.5.23" }
```

npm requires those two specs to be **identical**. They match today, so `main` installs fine — but the moment anything changes one side, npm aborts:

```
npm error code EOVERRIDE
npm error Override for postcss@8.5.23 conflicts with direct dependency
```

That is exactly what blocks #430 (`chore: pin dependencies`). Pinning strips the caret from the devDependency (`^8.5.23` → `8.5.23`) but leaves the override at `^8.5.23`, so `npm-build` fails during install — in ~6s, before it ever reaches a build step. A rebase does not help, because the inconsistency is on `main`, not in the PR.

## Fix

Use npm's `$name` self-reference so the override always tracks whatever the direct dependency resolves to:

```diff
   "overrides": {
-    "postcss": "^8.5.23",
+    "postcss": "$postcss",
     "sharp": "$sharp",
```

This matches the `"sharp": "$sharp"` line directly below it, which already uses this pattern. It fixes the whole class of problem rather than this one instance — future postcss pins and bumps can no longer desync.

## Verification

- `npm install --package-lock-only` succeeds and leaves `package-lock.json` **unchanged** — `$postcss` resolves to the same tree as `^8.5.23`, so there is no behavioural change.
- Re-ran with `postcss` pinned to the exact `8.5.23` that #430 sets, reproducing the failing condition: installs cleanly, no `EOVERRIDE`.
- Checked the other three overrides — `sharp` already uses `$sharp`; `brace-expansion` and `minimatch` are transitive-only, so neither is affected.

## Follow-up

Once this lands, rebase #430 (tick its checkbox on the Dependency Dashboard) and it should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)