### PR TITLE
feat: add semester course favorites

### DIFF
--- a/backend/src/ApiResource/UserApi.php
+++ b/backend/src/ApiResource/UserApi.php
@@ -9,6 +9,7 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Patch;
 use App\Constants\SerializationGroups;
 use App\Controller\Api\AddFavoriteToUserController;
+use App\Controller\Api\AddModuleCoursesToUserFavoritesController;
 use App\Controller\Api\RemoveFavoriteFromUserController;
 use App\Entity\User;
 use App\State\EntityClassDtoStateProcessor;
@@ -39,6 +40,11 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Patch(
             uriTemplate: 'users/{id}/favorites/add',
             controller: AddFavoriteToUserController::class,
+            normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::USER_FAVORITES]],
+        ),
+        new Patch(
+            uriTemplate: 'users/{id}/favorites/add-module-courses',
+            controller: AddModuleCoursesToUserFavoritesController::class,
             normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::USER_FAVORITES]],
         ),
         new Patch(

--- a/backend/src/Controller/Api/AddModuleCoursesToUserFavoritesController.php
+++ b/backend/src/Controller/Api/AddModuleCoursesToUserFavoritesController.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Controller\Api;
+
+use ApiPlatform\Metadata\IriConverterInterface;
+use App\ApiResource\ModuleApi;
+use App\ApiResource\UserApi;
+use App\Entity\Module;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfonycasts\MicroMapper\MicroMapperInterface;
+
+class AddModuleCoursesToUserFavoritesController extends AbstractController
+{
+    public function __construct(
+        private readonly Security $security,
+        private readonly MicroMapperInterface $microMapper,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly SerializerInterface $serializer,
+        private readonly IriConverterInterface $iriConverter,
+    ) {}
+
+    public function __invoke(UserApi $userApi, Request $request): Response
+    {
+        $user = $this->security->getUser();
+        assert($user instanceof User);
+
+        $requestBody = json_decode($request->getContent(), true);
+        $moduleIri = is_array($requestBody) ? ($requestBody['module'] ?? null) : null;
+        if (!is_string($moduleIri)) {
+            throw new BadRequestHttpException('A module IRI is required.');
+        }
+
+        $moduleApi = $this->iriConverter->getResourceFromIri($moduleIri);
+        if (!$moduleApi instanceof ModuleApi) {
+            throw new BadRequestHttpException('The supplied IRI is not a module.');
+        }
+
+        $module = $this->microMapper->map(
+            $moduleApi,
+            Module::class,
+            [MicroMapperInterface::MAX_DEPTH => 0]
+        );
+
+        $visitedModules = [];
+        $this->addModuleCourses($user, $module, $visitedModules);
+        $this->entityManager->flush();
+
+        $newUserApi = $this->microMapper->map(
+            $user,
+            UserApi::class,
+            [MicroMapperInterface::MAX_DEPTH => 1]
+        );
+        $serializedUserApi = $this->serializer->serialize(
+            $newUserApi,
+            'json',
+            [AbstractNormalizer::GROUPS => ['user:favorites']]
+        );
+
+        return new Response($serializedUserApi, Response::HTTP_OK);
+    }
+
+    /**
+     * @param array<int, true> $visitedModules
+     */
+    private function addModuleCourses(User $user, Module $module, array &$visitedModules): void
+    {
+        $moduleId = $module->getId();
+        if ($moduleId === null || isset($visitedModules[$moduleId])) {
+            return;
+        }
+        $visitedModules[$moduleId] = true;
+
+        foreach ($module->getCourses() as $course) {
+            $user->addFavoriteCourse($course);
+        }
+
+        foreach ($module->getModules() as $submodule) {
+            $this->addModuleCourses($user, $submodule, $visitedModules);
+        }
+    }
+}

--- a/backend/tests/Api/UserResourceTest.php
+++ b/backend/tests/Api/UserResourceTest.php
@@ -222,6 +222,90 @@ class UserResourceTest extends ApiTestCase
             ->assertStatus(403);
     }
 
+    public function testAddAllCoursesFromModuleTreeToFavorites(): void
+    {
+        $nestedOption = ModuleFactory::createOne(
+            [
+                'program' => null,
+                'name' => 'Nested option',
+                'modules' => [],
+            ]
+        );
+        $option = ModuleFactory::createOne(
+            [
+                'program' => null,
+                'name' => 'Elective option',
+                'modules' => [$nestedOption],
+            ]
+        );
+        $semester = ModuleFactory::createOne(
+            [
+                'name' => 'Semester 1',
+                'modules' => [$option],
+            ]
+        );
+
+        $directCourse = CourseFactory::createOne(['modules' => [$semester]]);
+        $optionCourse = CourseFactory::createOne(['modules' => [$option]]);
+        $nestedCourse = CourseFactory::createOne(['modules' => [$nestedOption]]);
+        $existingFavorite = CourseFactory::createOne();
+        $user = UserFactory::createOne(
+            [
+                'plainPassword' => 'password',
+                'favoriteCourses' => [$existingFavorite],
+            ]
+        );
+        $userToken = $this->getToken($user->getUsername(), 'password');
+
+        $expectedFavorites = [
+            '/api/courses/' . $directCourse->getId(),
+            '/api/courses/' . $optionCourse->getId(),
+            '/api/courses/' . $nestedCourse->getId(),
+            '/api/courses/' . $existingFavorite->getId(),
+        ];
+
+        foreach (range(1, 2) as $_attempt) {
+            $json = $this->browser()
+                ->patch(
+                    '/api/users/' . $user->getId() . '/favorites/add-module-courses',
+                    [
+                        'headers' => [
+                            'Content-Type' => 'application/merge-patch+json',
+                            'Authorization' => 'Bearer ' . $userToken,
+                        ],
+                        'json' => [
+                            'module' => '/api/modules/' . $semester->getId(),
+                        ],
+                    ]
+                )
+                ->assertStatus(200)
+                ->assertJson()
+                ->json()
+                ->decoded();
+
+            $this->assertEqualsCanonicalizing($expectedFavorites, $json['favoriteCourses']);
+        }
+
+        refresh($user);
+        self::assertCount(4, $user->getFavoriteCourses());
+
+        $otherUser = UserFactory::createOne();
+        $this->browser()
+            ->patch(
+                '/api/users/' . $otherUser->getId() . '/favorites/add-module-courses',
+                [
+                    'headers' => [
+                        'Content-Type' => 'application/merge-patch+json',
+                        'Authorization' => 'Bearer ' . $userToken,
+                    ],
+                    'json' => [
+                        'module' => '/api/modules/' . $semester->getId(),
+                    ],
+                ]
+            )
+            ->assertStatus(403);
+    }
+
     public function testRemoveFavorites(): void
     {
         $course1 = CourseFactory::createOne();

--- a/frontend/src/components/courses/ModuleNode.tsx
+++ b/frontend/src/components/courses/ModuleNode.tsx
@@ -1,6 +1,7 @@
 import { CourseRow } from '@/components/courses/CourseRow';
 import { CourseTableHeader } from '@/components/courses/CourseTableHeader';
 import { SearchFilters } from '@/components/courses/CurriculumSearchBar';
+import SemesterFavoriteButton from '@/components/courses/SemesterFavoriteButton';
 import DownloadButton from '@/components/ui/DownloadButton';
 import { useApi } from '@/hooks/useApi';
 import type { Course, Module } from '@/types/entities';
@@ -98,6 +99,7 @@ const ModuleNode = ({
     const { courses: matchingCourses, modules: matchingModules } = getChildMatches();
     const totalMatches = matchingCourses + matchingModules;
     const contentId = `module-content-${module.id}`;
+    const isSemester = /^Semester\s+\d+$/iu.test(module.name?.trim() ?? '');
 
     return (
         <div className="module-node mb-1">
@@ -126,6 +128,7 @@ const ModuleNode = ({
                     )}
                 </button>
 
+                {isSemester && <SemesterFavoriteButton moduleId={module.id} />}
                 <DownloadButton modules={[module]} />
             </div>
 

--- a/frontend/src/components/courses/SemesterFavoriteButton.tsx
+++ b/frontend/src/components/courses/SemesterFavoriteButton.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useUser } from '@/components/UserContext';
+import { useToast } from '@/components/ui/Toast';
+import { useFavorites } from '@/hooks/useFavorites';
+import { Check, LoaderCircle, Star } from 'lucide-react';
+import { useState, type MouseEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface SemesterFavoriteButtonProps {
+    moduleId: number;
+}
+
+export default function SemesterFavoriteButton({ moduleId }: SemesterFavoriteButtonProps) {
+    const { t } = useTranslation();
+    const { user } = useUser();
+    const { showToast } = useToast();
+    const { addModuleCourses, loading } = useFavorites(user);
+    const [added, setAdded] = useState(false);
+
+    if (!user) return null;
+
+    const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (loading) return;
+
+        if (added) {
+            showToast(t('curriculum-navigator.semester-favorites.already-added'), 'success');
+            return;
+        }
+
+        try {
+            await addModuleCourses(moduleId);
+            setAdded(true);
+            showToast(t('curriculum-navigator.semester-favorites.added'), 'success');
+        } catch {
+            showToast(t('curriculum-navigator.semester-favorites.error'), 'error');
+        }
+    };
+
+    return (
+        <button
+            type="button"
+            onClick={handleClick}
+            aria-disabled={loading || added}
+            aria-label={t('curriculum-navigator.semester-favorites.add-title')}
+            title={t('curriculum-navigator.semester-favorites.add-title')}
+            className="vtk-button vtk-button-subtle vtk-button-sm shrink-0"
+        >
+            {loading ? (
+                <LoaderCircle size={15} className="animate-spin" />
+            ) : added ? (
+                <Check size={15} />
+            ) : (
+                <Star size={15} />
+            )}
+            <span className="hidden lg:inline">
+                {added
+                    ? t('curriculum-navigator.semester-favorites.added-label')
+                    : t('curriculum-navigator.semester-favorites.add-label')}
+            </span>
+        </button>
+    );
+}

--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { Suspense, useState } from 'react';
+import { Suspense, useState, type CSSProperties } from 'react';
 import { Dialog } from '@headlessui/react';
 import { Menu, X } from 'lucide-react';
 import { Skeleton } from "@/components/ui/skeleton";
@@ -9,8 +9,23 @@ import HeaderProfileButton from "@/components/header/HeaderProfileButton";
 import { useUser } from '@/components/UserContext';
 import { useTranslation } from 'react-i18next';
 import LanguageSwitcher from '@/components/header/LanguageSwitcher';
-import Image from 'next/image';
 import Link from 'next/link';
+
+const vtkLogoMaskStyle: CSSProperties = {
+    backgroundColor: '#c8c9cd',
+    maskImage: "url('/images/logos/vtk-logo-white.png')",
+    maskPosition: 'left center',
+    maskRepeat: 'no-repeat',
+    maskSize: 'contain',
+    WebkitMaskImage: "url('/images/logos/vtk-logo-white.png')",
+    WebkitMaskPosition: 'left center',
+    WebkitMaskRepeat: 'no-repeat',
+    WebkitMaskSize: 'contain',
+};
+
+const HeaderLogo = ({ className }: { className: string }) => (
+    <span aria-hidden="true" className={className} style={vtkLogoMaskStyle} />
+);
 
 /**
  * Sticky navy header with light navigation: the same dark bookend as the
@@ -46,14 +61,7 @@ export default function Header() {
                 {/* Brand */}
                 <Link href={`/${i18n.language}`} className="flex shrink-0 items-center gap-4">
                     <span className="sr-only">Burgieclan</span>
-                    <Image
-                        src="/images/logos/vtk-logo-white.png"
-                        alt=""
-                        width={140}
-                        height={38}
-                        className="h-[34px] w-auto max-w-[150px] object-contain object-left"
-                        priority
-                    />
+                    <HeaderLogo className="block h-[34px] w-[60px] shrink-0" />
                     {/* Optical nudge: flex centring aligns the full line box, which
                         leaves the cap-height block sitting high against the mark. */}
                     <span className="hidden translate-y-[2px] text-xl font-bold tracking-tight lg:inline">Burgieclan</span>
@@ -125,13 +133,7 @@ export default function Header() {
                     <div className="flex items-center justify-between">
                         <Link href={`/${i18n.language}`} className="flex shrink-0 items-center gap-2.5">
                             <span className="sr-only">Burgieclan</span>
-                            <Image
-                                src="/images/logos/vtk-logo-white.png"
-                                alt=""
-                                width={140}
-                                height={38}
-                                className="h-[32px] w-auto object-contain object-left"
-                            />
+                            <HeaderLogo className="block h-[32px] w-[57px] shrink-0" />
                         </Link>
                         <button
                             type="button"

--- a/frontend/src/components/layout/ItemList.tsx
+++ b/frontend/src/components/layout/ItemList.tsx
@@ -26,29 +26,27 @@ const ItemList: React.FC<ItemListProps> = ({ items, emptyMessage }) => {
                     {displayedItems.map((item) => (
                         <li
                             key={`${item.type}-${item.id}`}
-                            className="group rounded-lg transition-colors duration-100 hover:bg-vtk-paper-2"
+                            className="group relative rounded-lg transition-colors duration-100 hover:bg-vtk-paper-2"
                         >
-                            <div className="flex w-full items-center px-2 py-1.5">
-                                <Link
-                                    href={item.redirectUrl}
-                                    className="flex-1 min-w-0"
-                                >
-                                    <div className="flex items-center overflow-hidden">
-                                        <span className="truncate text-vtk-body text-sm font-normal">
-                                            {item.name}
-                                            {item.code && <span className="text-vtk-muted ml-1 text-xs">({item.code})</span>}
-                                        </span>
-                                    </div>
-                                </Link>
-                                <div className="ml-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-within:opacity-100 transition-opacity duration-100">
-                                    <FavoriteButton
-                                        itemId={item.id}
-                                        itemType={item.type}
-                                        size={14}
-                                        className="p-0.5"
-                                        colorScheme="gray"
-                                    />
+                            <Link
+                                href={item.redirectUrl}
+                                className="flex w-full min-w-0 items-center rounded-lg px-2 py-1.5 pr-9 focus-visible:ring-2 focus-visible:ring-vtk-ink/20"
+                            >
+                                <div className="flex min-w-0 items-center overflow-hidden">
+                                    <span className="truncate text-sm font-normal text-vtk-body">
+                                        {item.name}
+                                        {item.code && <span className="ml-1 text-xs text-vtk-muted">({item.code})</span>}
+                                    </span>
                                 </div>
+                            </Link>
+                            <div className="absolute inset-y-0 right-2 z-10 flex items-center opacity-0 transition-opacity duration-100 focus-within:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100">
+                                <FavoriteButton
+                                    itemId={item.id}
+                                    itemType={item.type}
+                                    size={14}
+                                    className="p-0.5"
+                                    colorScheme="gray"
+                                />
                             </div>
                         </li>
                     ))}

--- a/frontend/src/components/upload/UploadDialog.tsx
+++ b/frontend/src/components/upload/UploadDialog.tsx
@@ -1,4 +1,4 @@
-import { Dialog, DialogActions, DialogBody, DialogTitle } from '@/components/ui/Dialog';
+import { Dialog, DialogBody, DialogTitle } from '@/components/ui/Dialog';
 import { Text } from '@/components/ui/Text';
 import { useToast } from '@/components/ui/Toast';
 import UploadForm from '@/components/upload/UploadForm';
@@ -49,42 +49,44 @@ const UploadDialog = ({
             isOpen={isOpen}
             onClose={handleClose}
             size="3xl"
+            className="flex max-h-[calc(100dvh-2rem)] flex-col overflow-hidden p-0! sm:max-h-[calc(100dvh-4rem)] sm:p-0!"
         >
-            <DialogTitle>
-                {t('upload.dialog.title')}
-            </DialogTitle>
-            <DialogBody>
-                <Text className="max-w-[62ch] text-vtk-body">
+            <div className="shrink-0 border-b border-vtk-line px-5 py-5 pr-16 sm:px-8 sm:pr-16">
+                <DialogTitle className="m-0! px-0!">
+                    {t('upload.dialog.title')}
+                </DialogTitle>
+                <Text className="mt-2 text-sm leading-6! text-vtk-body">
                     {t('upload.dialog.description')}
                 </Text>
+            </div>
 
+            <DialogBody className="mt-0! min-h-0 overflow-y-auto overscroll-contain px-5! py-5 sm:px-8!">
                 <UploadForm
                     onSubmit={handleSubmit}
                     isLoading={isLoading}
                     initialFile={initialFile}
                     initialData={initialData}
+                    submitAction={(
+                        <button
+                            type="submit"
+                            disabled={isLoading || status.type === 'success'}
+                            className="primary-button w-full sm:w-auto"
+                        >
+                            {isLoading ? (
+                                <>
+                                    <span className="spinner mr-2" />
+                                    {t('upload.dialog.button.uploading')}
+                                </>
+                            ) : (
+                                <>
+                                    <Send className="h-4 w-4" />
+                                    {t('upload.dialog.button.send')}
+                                </>
+                            )}
+                        </button>
+                    )}
                 />
             </DialogBody>
-            <DialogActions className="mt-0!"> {/* mt-0! removes the top margin */}
-                <button
-                    type="submit"
-                    form="upload-form"
-                    disabled={isLoading || status.type === 'success'}
-                    className="primary-button inline-flex items-center"
-                >
-                    {isLoading ? (
-                        <>
-                            <span className="spinner mr-2" />
-                            {t('upload.dialog.button.uploading')}
-                        </>
-                    ) : (
-                        <>
-                            <Send className="mr-2 w-5 h-5" />
-                            {t('upload.dialog.button.send')}
-                        </>
-                    )}
-                </button>
-            </DialogActions>
         </Dialog>
     );
 };

--- a/frontend/src/components/upload/UploadForm.tsx
+++ b/frontend/src/components/upload/UploadForm.tsx
@@ -13,7 +13,7 @@ import { getSuggestedNameFromFilename } from '@/utils/documentNameSuggestion';
 import { documentSchema } from '@/utils/validation/documentSchema';
 import { localizedCourseName } from '@/utils/courseName';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useForm, useWatch, type FieldError } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -25,6 +25,7 @@ interface FormProps {
         course?: Course;
         category?: DocumentCategory;
     };
+    submitAction: ReactNode;
 }
 
 export default function UploadForm({
@@ -32,6 +33,7 @@ export default function UploadForm({
     isLoading = false,
     initialFile,
     initialData,
+    submitAction,
 }: FormProps) {
     const { t, i18n } = useTranslation();
     const { user } = useUser();
@@ -120,14 +122,14 @@ export default function UploadForm({
     };
 
     return (
-        <form id="upload-form" onSubmit={handleSubmit(onSubmit)} className="pt-6 space-y-6">
+        <form id="upload-form" onSubmit={handleSubmit(onSubmit)}>
             {error && (
                 <div className="mb-4">
                     <Text className="vtk-error-text">{error}</Text>
                 </div>
             )}
 
-            <div className="grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-4">
+            <div className="grid grid-cols-1 gap-x-6 gap-y-3 md:grid-cols-6">
                 <div className="col-span-full">
                     <FormField
                         label={t('upload.form.name.label')}
@@ -139,7 +141,7 @@ export default function UploadForm({
                     />
                 </div>
 
-                <div className="sm:col-span-3">
+                <div className="md:col-span-4">
                     <FormField
                         label={t('upload.form.course.label')}
                         type="combobox"
@@ -151,7 +153,7 @@ export default function UploadForm({
                     />
                 </div>
 
-                <div className="sm:col-span-1">
+                <div className="md:col-span-2">
                     <FormField
                         label={t('upload.form.year.label')}
                         type="combobox"
@@ -164,7 +166,7 @@ export default function UploadForm({
                     />
                 </div>
 
-                <div className="sm:col-span-2">
+                <div className="md:col-span-3">
                     <FormField
                         label={t('upload.form.category.label')}
                         type="combobox"
@@ -176,7 +178,7 @@ export default function UploadForm({
                     />
                 </div>
 
-                <div className="sm:col-span-2">
+                <div className="md:col-span-3">
                     <label className="block text-sm font-medium text-vtk-ink">
                         {t('upload.form.tags.label')}
                     </label>
@@ -195,13 +197,13 @@ export default function UploadForm({
                     />
                 </div>
 
-                <div className="col-span-full mt-4 gap-3 pb-2">
+                <div className="col-span-full mt-1 flex flex-col gap-4 border-t border-vtk-line pt-4 sm:flex-row sm:items-center sm:justify-between">
                     <Checkbox
                         label={t('upload.form.anonymous.label')}
                         {...register('anonymous')}
                         disabled={isLoading}
-                        className="justify-end"
                     />
+                    {submitAction}
                 </div>
             </div>
         </form>

--- a/frontend/src/hooks/useFavorites.ts
+++ b/frontend/src/hooks/useFavorites.ts
@@ -6,37 +6,34 @@ import { useState } from "react";
 
 type FavoriteType = "course" | "module" | "program" | "document";
 
+const favoriteBodyKeys: Record<FavoriteType, string> = {
+    course: 'favoriteCourses',
+    module: 'favoriteModules',
+    program: 'favoritePrograms',
+    document: 'favoriteDocuments',
+};
+
+const favoriteIriSegments: Record<FavoriteType, string> = {
+    course: 'courses',
+    module: 'modules',
+    program: 'programs',
+    document: 'documents',
+};
+
 export function useFavorites(userParam?: User | null) {
     const { request, loading } = useApi();
     const { user: contextUser, refreshUser } = useUser();
     const user = userParam !== undefined ? userParam : contextUser;
     const [error, setError] = useState<Error | null>(null);
 
-    const updateFavorite = async (id: number, type: FavoriteType, isFavorite: boolean) => {
+    const submitFavoriteUpdate = async (endpoint: string, body: Record<string, string | string[]>) => {
         if (!user) return null;
-
         setError(null);
 
         try {
-            let body;
-            switch (type) {
-                case "course":
-                    body = { favoriteCourses: [`/api/courses/${id}`] };
-                    break;
-                case "module":
-                    body = { favoriteModules: [`/api/modules/${id}`] };
-                    break;
-                case "program":
-                    body = { favoritePrograms: [`/api/programs/${id}`] };
-                    break;
-                case "document":
-                    body = { favoriteDocuments: [`/api/documents/${id}`] };
-                    break;
-            }
-
             const result = await request(
                 'PATCH',
-                `/api/users/${user.id}/favorites/${isFavorite ? 'add' : 'remove'}`,
+                `/api/users/${user.id}/favorites/${endpoint}`,
                 body
             );
 
@@ -61,8 +58,23 @@ export function useFavorites(userParam?: User | null) {
         }
     };
 
+    const updateFavorite = async (id: number, type: FavoriteType, isFavorite: boolean) => {
+        return submitFavoriteUpdate(
+            isFavorite ? 'add' : 'remove',
+            { [favoriteBodyKeys[type]]: [`/api/${favoriteIriSegments[type]}/${id}`] }
+        );
+    };
+
+    const addModuleCourses = async (moduleId: number) => {
+        return submitFavoriteUpdate(
+            'add-module-courses',
+            { module: `/api/modules/${moduleId}` }
+        );
+    };
+
     return {
         updateFavorite,
+        addModuleCourses,
         loading,
         error
     };

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -276,7 +276,15 @@
         "no-modules-in-program": "No modules available in this program.",
         "no-courses-in-module": "No courses available in this module.",
         "meta-programs": "programs",
-        "meta-courses": "courses"
+        "meta-courses": "courses",
+        "semester-favorites": {
+            "add-label": "Add semester",
+            "added-label": "Added",
+            "add-title": "Add every course in this semester to My Courses",
+            "added": "The semester's courses were added to My Courses.",
+            "already-added": "Every course in this semester is already in My Courses.",
+            "error": "Could not add this semester to My Courses. Please try again."
+        }
     },
     "account": {
         "menu": "User menu",

--- a/frontend/src/translations/nl.json
+++ b/frontend/src/translations/nl.json
@@ -276,7 +276,15 @@
         "no-modules-in-program": "Deze richting bevat geen modules.",
         "no-courses-in-module": "Deze module bevat geen vakken.",
         "meta-programs": "richtingen",
-        "meta-courses": "vakken"
+        "meta-courses": "vakken",
+        "semester-favorites": {
+            "add-label": "Semester toevoegen",
+            "added-label": "Toegevoegd",
+            "add-title": "Voeg alle vakken van dit semester toe aan Mijn vakken",
+            "added": "De vakken van dit semester zijn toegevoegd aan Mijn vakken.",
+            "already-added": "Alle vakken van dit semester staan al in Mijn vakken.",
+            "error": "Dit semester kon niet aan Mijn vakken worden toegevoegd. Probeer opnieuw."
+        }
     },
     "account": {
         "menu": "Gebruikersmenu",


### PR DESCRIPTION
## Summary
- make the full visual rows in My Courses and Favorite Documents clickable while keeping the star action separate
- add an atomic semester action that favorites every course in the full nested module tree
- make the upload dialog compact, responsive, and viewport-bounded
- render the header VTK logo in #c8c9cd on desktop and mobile

## Testing
- npm run lint (passes with one pre-existing LoginForm warning)
- npm run build
- vendor/bin/phpstan analyze --memory-limit=512M --no-progress
- vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1
- vendor/bin/phpunit tests (335 tests, 2148 assertions; one pre-existing Foundry deprecation)