### PR TITLE
feat: verwerk studentenfeedback over navigatie, uploaden en sessies

### DIFF
--- a/backend/src/ApiResource/CourseApi.php
+++ b/backend/src/ApiResource/CourseApi.php
@@ -9,6 +9,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use App\Constants\SerializationGroups;
+use App\Controller\Api\GetCoursePathsController;
 use App\Entity\Course;
 use App\State\EntityClassDtoStateProcessor;
 use App\State\EntityClassDtoStateProvider;
@@ -20,6 +21,13 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new Get(normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::COURSE_GET]]),
         new GetCollection(normalizationContext: ['groups' => [SerializationGroups::BASE_READ, SerializationGroups::COURSE_GET]]),
+        // Lets a course page name the branch it sits in without downloading the curriculum.
+        new Get(
+            uriTemplate: 'courses/{id}/paths',
+            controller: GetCoursePathsController::class,
+            read: false,
+            name: 'course_paths',
+        ),
     ],
     provider: EntityClassDtoStateProvider::class,
     processor: EntityClassDtoStateProcessor::class,
@@ -158,4 +166,15 @@ class CourseApi extends BaseEntityApi
      */
     #[Groups([SerializationGroups::COURSE_GET])]
     public array $documentCounts = [];
+
+    /**
+     * Published documents on this course, as a single total.
+     *
+     * Only filled in for the related courses hanging off a course detail response, where it is
+     * the whole point of the link: a reader has no way of knowing that the predecessor of a
+     * near-empty course holds a decade of exams. Null everywhere else - counting it for every
+     * row of an expanded module would cost a query per course for a number nothing renders.
+     */
+    #[Groups([SerializationGroups::COURSE_GET])]
+    public ?int $documentCount = null;
 }

--- a/backend/src/Controller/Api/GetCoursePathsController.php
+++ b/backend/src/Controller/Api/GetCoursePathsController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Controller\Api;
+
+use App\Entity\Module;
+use App\Repository\CourseRepository;
+use App\Service\CurriculumPathResolver;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Every place a course appears in the curriculum: for each one, the program and the chain of
+ * modules leading down to the module that teaches it.
+ *
+ * A course page is usually reached from a search, a favourite or a shared link, none of which
+ * carry the branch the reader came through. Without it the page cannot say which programme and
+ * semester the course belongs to, which is the orientation the folder tree used to give for
+ * free. Names travel with the IRIs so a breadcrumb needs no follow-up request per node.
+ */
+class GetCoursePathsController extends AbstractController
+{
+    public function __construct(
+        private readonly CourseRepository $courseRepository,
+        private readonly CurriculumPathResolver $pathResolver,
+    ) {}
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        // The operation reads nothing, so the course is looked up here rather than through the
+        // state provider: the DTO it would build is thrown away anyway.
+        $id = $request->attributes->get('id');
+        $course = is_scalar($id) ? $this->courseRepository->find($id) : null;
+        if ($course === null) {
+            throw new NotFoundHttpException('Course not found.');
+        }
+
+        $paths = array_map(
+            static fn(array $path): array => [
+                'program' => [
+                    '@id' => '/api/programs/' . $path['program']->getId(),
+                    'name' => $path['program']->getName(),
+                ],
+                'modules' => array_map(
+                    static fn(Module $module): array => [
+                        '@id' => '/api/modules/' . $module->getId(),
+                        'name' => $module->getName(),
+                    ],
+                    $path['modules']
+                ),
+            ],
+            $this->pathResolver->resolveCourse($course)
+        );
+
+        return new JsonResponse(['paths' => array_values($paths)]);
+    }
+}

--- a/backend/src/Controller/Api/GetModulePathController.php
+++ b/backend/src/Controller/Api/GetModulePathController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api;
 
 use App\Entity\Module;
 use App\Repository\ModuleRepository;
+use App\Service\CurriculumPathResolver;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -14,13 +15,13 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  * from that program's top level down to the module itself.
  *
  * The navigator loads one level at a time, so a link straight to a nested module has no way of
- * knowing which branches to open. Walking up costs one query per level and the tree is a handful
- * deep; walking down from every program would mean pulling the whole curriculum to place one node.
+ * knowing which branches to open.
  */
 class GetModulePathController extends AbstractController
 {
     public function __construct(
         private readonly ModuleRepository $moduleRepository,
+        private readonly CurriculumPathResolver $pathResolver,
     ) {}
 
     public function __invoke(Request $request): JsonResponse
@@ -33,68 +34,22 @@ class GetModulePathController extends AbstractController
             throw new NotFoundHttpException('Module not found.');
         }
 
-        $chain = $this->ancestorChain($module);
+        $path = $this->pathResolver->resolveModule($module);
 
-        // A program's top level is drawn from the modules that point at it, so the path has to
-        // start at the highest ancestor that has one. Anything above that is not rendered under
-        // any program and would leave the link with nothing to open.
-        $program = null;
-        $path = [];
-        foreach ($chain as $index => $ancestor) {
-            $ancestorProgram = $ancestor->getProgram();
-            if ($ancestorProgram !== null) {
-                $program = $ancestorProgram;
-                $path = array_slice($chain, $index);
-                break;
-            }
-        }
-
-        if ($program === null) {
+        if ($path === null) {
             return new JsonResponse(['program' => null, 'modules' => []]);
         }
 
         $moduleIris = array_map(
             static fn(Module $ancestor): string => '/api/modules/' . $ancestor->getId(),
-            $path
+            $path['modules']
         );
 
-        $payload = [
-            'program' => '/api/programs/' . $program->getId(),
+        return new JsonResponse(
+            [
+            'program' => '/api/programs/' . $path['program']->getId(),
             'modules' => array_values($moduleIris),
-        ];
-
-        return new JsonResponse($payload);
-    }
-
-    /**
-     * The module's ancestors, root-most first, with the module itself last.
-     *
-     * @return Module[]
-     */
-    private function ancestorChain(Module $module): array
-    {
-        $chain = [$module];
-        $seen = [$module->getId() => true];
-        $current = $module;
-
-        // In practice a module hangs under a single parent, but the mapping is many-to-many: take
-        // the first parent not already walked and let $seen break any cycle the data allows.
-        while (true) {
-            $parent = null;
-            foreach ($this->moduleRepository->findParentModules($current) as $candidate) {
-                if (!isset($seen[$candidate->getId()])) {
-                    $parent = $candidate;
-                    break;
-                }
-            }
-
-            if ($parent === null) {
-                return $chain;
-            }
-
-            $seen[$parent->getId()] = true;
-            array_unshift($chain, $parent);
-            $current = $parent;
-        }
+            ]
+        );
     }
 }

--- a/backend/src/Mapper/CourseEntityToApiMapper.php
+++ b/backend/src/Mapper/CourseEntityToApiMapper.php
@@ -51,58 +51,9 @@ class CourseEntityToApiMapper extends BaseEntityToApiMapper
             return $to;
         }
 
-        $to->oldCourses = array_map(
-            function (Course $course) {
-                return $this->microMapper->map(
-                    $course,
-                    CourseApi::class,
-                    [
-                        // SUMMARY + depth 1, not depth 0: MicroMapper skips populate()
-                        // entirely at depth 0, which would leave a related course with an
-                        // IRI and no code or name to render. SUMMARY stops it there, so it
-                        // does not walk on into its own relations.
-                        MappingContext::SUMMARY => true,
-                        MicroMapperInterface::MAX_DEPTH => 1,
-                    ]
-                );
-            },
-            $from->getOldCourses()->getValues()
-        );
-        $to->newCourses = array_map(
-            function (Course $course) {
-                return $this->microMapper->map(
-                    $course,
-                    CourseApi::class,
-                    [
-                        // SUMMARY + depth 1, not depth 0: MicroMapper skips populate()
-                        // entirely at depth 0, which would leave a related course with an
-                        // IRI and no code or name to render. SUMMARY stops it there, so it
-                        // does not walk on into its own relations.
-                        MappingContext::SUMMARY => true,
-                        MicroMapperInterface::MAX_DEPTH => 1,
-                    ]
-                );
-            },
-            $from->getNewCourses()->getValues()
-        );
-
-        $to->identicalCourses = array_map(
-            function (Course $course) {
-                return $this->microMapper->map(
-                    $course,
-                    CourseApi::class,
-                    [
-                        // SUMMARY + depth 1, not depth 0: MicroMapper skips populate()
-                        // entirely at depth 0, which would leave a related course with an
-                        // IRI and no code or name to render. SUMMARY stops it there, so it
-                        // does not walk on into its own relations.
-                        MappingContext::SUMMARY => true,
-                        MicroMapperInterface::MAX_DEPTH => 1,
-                    ]
-                );
-            },
-            $from->getIdenticalCourses()->getValues()
-        );
+        $to->oldCourses = $this->mapRelatedCourses($from->getOldCourses()->getValues());
+        $to->newCourses = $this->mapRelatedCourses($from->getNewCourses()->getValues());
+        $to->identicalCourses = $this->mapRelatedCourses($from->getIdenticalCourses()->getValues());
 
         $to->modules = array_map(
             function (Module $module) {
@@ -133,6 +84,49 @@ class CourseEntityToApiMapper extends BaseEntityToApiMapper
         $to->documentCounts = $this->documentRepository->countByCategoryForCourse($from);
 
         return $to;
+    }
+
+    /**
+     * The courses a reader can jump to from this one - predecessors, successors and equivalents -
+     * each carrying how many documents it holds.
+     *
+     * The count is the reason the link is worth following: after a curriculum reform the current
+     * course is often near-empty while its predecessor holds years of exams, and without a number
+     * on the badge there is nothing telling the reader that. Counting them together keeps it at
+     * one query no matter how many related courses there are.
+     *
+     * @param Course[] $courses
+     * @return CourseApi[]
+     */
+    private function mapRelatedCourses(array $courses): array
+    {
+        if ([] === $courses) {
+            return [];
+        }
+
+        $counts = $this->documentRepository->countPublishedForCourses($courses);
+
+        return array_map(
+            function (Course $course) use ($counts): CourseApi {
+                /** @var CourseApi $dto */
+                $dto = $this->microMapper->map(
+                    $course,
+                    CourseApi::class,
+                    [
+                        // SUMMARY + depth 1, not depth 0: MicroMapper skips populate()
+                        // entirely at depth 0, which would leave a related course with an
+                        // IRI and no code or name to render. SUMMARY stops it there, so it
+                        // does not walk on into its own relations.
+                        MappingContext::SUMMARY => true,
+                        MicroMapperInterface::MAX_DEPTH => 1,
+                    ]
+                );
+                $dto->documentCount = $counts[$course->getId()] ?? 0;
+
+                return $dto;
+            },
+            $courses
+        );
     }
 
     /**

--- a/backend/src/Mapper/DocumentEntityToApiMapper.php
+++ b/backend/src/Mapper/DocumentEntityToApiMapper.php
@@ -67,9 +67,10 @@ class DocumentEntityToApiMapper extends BaseEntityToApiMapper
                 MicroMapperInterface::MAX_DEPTH => 1,
             ]
         );
-        if ($context[MappingContext::INCLUDE_FILE_METADATA] ?? true) {
-            $to->contentUrl = $this->storage->resolveUri($from, 'file');
-        }
+        // Always resolved, unlike the size and MIME type the provider fills in: this is a
+        // string built from the stored filename, with no filesystem access behind it, and a
+        // document row needs it to offer "open in the browser" next to its download button.
+        $to->contentUrl = $this->storage->resolveUri($from, 'file');
         $to->tags = array_map(
             function (Tag $tag) {
                 return $this->microMapper->map(

--- a/backend/src/Repository/DocumentRepository.php
+++ b/backend/src/Repository/DocumentRepository.php
@@ -97,6 +97,39 @@ class DocumentRepository extends ServiceEntityRepository
         return $counts;
     }
 
+    /**
+     * Published document totals for a set of courses, as courseId => count.
+     *
+     * One query for the whole set: the related courses on a course page are counted together,
+     * so linking to a predecessor archive costs the same whether there is one or five.
+     *
+     * @param Course[] $courses
+     * @return array<int, int>
+     */
+    public function countPublishedForCourses(array $courses): array
+    {
+        if ([] === $courses) {
+            return [];
+        }
+
+        $rows = $this->createQueryBuilder('d')
+            ->select('IDENTITY(d.course) AS courseId, COUNT(d.id) AS docCount')
+            ->andWhere('d.course IN (:courses)')
+            ->andWhere('d.under_review = :under_review')
+            ->setParameter('courses', $courses)
+            ->setParameter('under_review', false)
+            ->groupBy('d.course')
+            ->getQuery()
+            ->getArrayResult();
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[(int) $row['courseId']] = (int) $row['docCount'];
+        }
+
+        return $counts;
+    }
+
 
     /**
      * @return Document[]

--- a/backend/src/Service/CurriculumPathResolver.php
+++ b/backend/src/Service/CurriculumPathResolver.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Course;
+use App\Entity\Module;
+use App\Entity\Program;
+use App\Repository\ModuleRepository;
+
+/**
+ * Places a node in the curriculum: the program it hangs under, plus the chain of modules from
+ * that program's top level down to the node itself.
+ *
+ * The navigator loads one level at a time and a course carries no programme of its own, so a
+ * page reached by a direct link has no way of telling the reader which branch they are in.
+ * Walking up costs one query per level and the tree is a handful deep; walking down from every
+ * program would mean pulling the whole curriculum to place one node.
+ */
+class CurriculumPathResolver
+{
+    public function __construct(
+        private readonly ModuleRepository $moduleRepository,
+    ) {}
+
+    /**
+     * Where one module sits, or null when no ancestor hangs under a program - such a module is
+     * drawn nowhere in the navigator, so there is no branch to point at.
+     *
+     * @return array{program: Program, modules: Module[]}|null
+     */
+    public function resolveModule(Module $module): ?array
+    {
+        $chain = $this->ancestorChain($module);
+
+        // A program's top level is drawn from the modules that point at it, so the path has to
+        // start at the highest ancestor that has one. Anything above that is not rendered under
+        // any program and would leave the link with nothing to open.
+        foreach ($chain as $index => $ancestor) {
+            $program = $ancestor->getProgram();
+            if ($program !== null) {
+                return [
+                    'program' => $program,
+                    'modules' => array_values(array_slice($chain, $index)),
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Every placement of a course, deduplicated and ordered by program name.
+     *
+     * A course is shared: the same Doctrine row hangs under one module per programme that
+     * teaches it, which is exactly what a reader asking "which branch am I in?" wants to see.
+     *
+     * @return array<int, array{program: Program, modules: Module[]}>
+     */
+    public function resolveCourse(Course $course): array
+    {
+        $paths = [];
+        $seen = [];
+
+        foreach ($course->getModules() as $module) {
+            $path = $this->resolveModule($module);
+            if ($path === null) {
+                continue;
+            }
+
+            $key = self::pathKey($path);
+            if (isset($seen[$key])) {
+                continue;
+            }
+
+            $seen[$key] = true;
+            $paths[] = $path;
+        }
+
+        usort(
+            $paths,
+            static function (array $a, array $b): int {
+                return [$a['program']->getName(), self::pathKey($a)]
+                <=> [$b['program']->getName(), self::pathKey($b)];
+            }
+        );
+
+        return $paths;
+    }
+
+    /**
+     * @param array{program: Program, modules: Module[]} $path
+     */
+    private static function pathKey(array $path): string
+    {
+        $moduleIds = array_map(static fn(Module $module): string => (string) $module->getId(), $path['modules']);
+
+        return $path['program']->getId() . ':' . implode('/', $moduleIds);
+    }
+
+    /**
+     * The module's ancestors, root-most first, with the module itself last.
+     *
+     * @return Module[]
+     */
+    private function ancestorChain(Module $module): array
+    {
+        $chain = [$module];
+        $seen = [$module->getId() => true];
+        $current = $module;
+
+        // In practice a module hangs under a single parent, but the mapping is many-to-many: take
+        // the first parent not already walked and let $seen break any cycle the data allows.
+        while (true) {
+            $parent = null;
+            foreach ($this->moduleRepository->findParentModules($current) as $candidate) {
+                if (!isset($seen[$candidate->getId()])) {
+                    $parent = $candidate;
+                    break;
+                }
+            }
+
+            if ($parent === null) {
+                return $chain;
+            }
+
+            $seen[$parent->getId()] = true;
+            array_unshift($chain, $parent);
+            $current = $parent;
+        }
+    }
+}

--- a/backend/tests/Api/CourseResourceTest.php
+++ b/backend/tests/Api/CourseResourceTest.php
@@ -413,17 +413,22 @@ class CourseResourceTest extends ApiTestCase
         $course = CourseFactory::createOne(['oldCourses' => [$predecessor]]);
         $category = DocumentCategoryFactory::createOne();
 
-        DocumentFactory::createMany(3, [
+        DocumentFactory::createMany(
+            3,
+            [
             'course' => $predecessor,
             'category' => $category,
             'under_review' => false,
-        ]);
+            ]
+        );
         // Pending uploads are invisible everywhere else, so they must not pad the count here.
-        DocumentFactory::createOne([
+        DocumentFactory::createOne(
+            [
             'course' => $predecessor,
             'category' => $category,
             'under_review' => true,
-        ]);
+            ]
+        );
 
         $this->browser()
             ->get(

--- a/backend/tests/Api/CourseResourceTest.php
+++ b/backend/tests/Api/CourseResourceTest.php
@@ -5,6 +5,8 @@ namespace App\Tests\Api;
 use App\Factory\CourseFactory;
 use App\Factory\DocumentCategoryFactory;
 use App\Factory\DocumentFactory;
+use App\Factory\ModuleFactory;
+use App\Factory\ProgramFactory;
 
 use function Zenstruck\Foundry\Persistence\save;
 
@@ -300,5 +302,140 @@ class CourseResourceTest extends ApiTestCase
         $this->assertArrayHasKey('documentCounts', $json);
         $this->assertSame(3, $json['documentCounts'][$category1->getId()]);
         $this->assertSame(2, $json['documentCounts'][$category2->getId()]);
+    }
+
+    /**
+     * A course page is reached from a search, a favourite or a shared link, none of which say
+     * which branch the reader is in. The paths endpoint is what lets it say so anyway.
+     */
+    public function testGetCoursePaths(): void
+    {
+        $course = CourseFactory::createOne(['modules' => []]);
+        $program = ProgramFactory::createOne();
+        $leaf = ModuleFactory::createOne(['program' => null, 'modules' => [], 'courses' => [$course]]);
+        $top = ModuleFactory::createOne(['program' => $program, 'modules' => [$leaf]]);
+
+        $this->browser()
+            ->get('/api/courses/' . $course->getId() . '/paths')
+            ->assertStatus(401)
+            ->get(
+                '/api/courses/' . $course->getId() . '/paths',
+                [
+                    'headers' => [
+                        'Authorization' => 'Bearer ' . $this->token
+                    ]
+                ]
+            )
+            ->assertStatus(200)
+            ->assertJson()
+            ->assertJsonMatches('length(paths)', 1)
+            ->assertJsonMatches('paths[0].program."@id"', '/api/programs/' . $program->getId())
+            ->assertJsonMatches('paths[0].program.name', $program->getName())
+            ->assertJsonMatches(
+                'paths[0].modules[*]."@id"',
+                [
+                    '/api/modules/' . $top->getId(),
+                    '/api/modules/' . $leaf->getId(),
+                ]
+            );
+    }
+
+    /**
+     * Half the engineering courses are shared, and the reader wants to know about all of them -
+     * "am I looking at the right Beton?" only has an answer if every placement is listed.
+     */
+    public function testGetCoursePathsListsEveryPlacement(): void
+    {
+        $course = CourseFactory::createOne(['modules' => []]);
+        $first = ProgramFactory::createOne(['name' => 'A program']);
+        $second = ProgramFactory::createOne(['name' => 'B program']);
+        ModuleFactory::createOne(['program' => $first, 'modules' => [], 'courses' => [$course]]);
+        ModuleFactory::createOne(['program' => $second, 'modules' => [], 'courses' => [$course]]);
+
+        $this->browser()
+            ->get(
+                '/api/courses/' . $course->getId() . '/paths',
+                [
+                    'headers' => [
+                        'Authorization' => 'Bearer ' . $this->token
+                    ]
+                ]
+            )
+            ->assertStatus(200)
+            ->assertJsonMatches('length(paths)', 2)
+            // Ordered by program name, so the list does not reshuffle between requests.
+            ->assertJsonMatches('paths[*].program.name', ['A program', 'B program']);
+    }
+
+    /**
+     * A course whose modules hang under no program is drawn nowhere in the navigator, so there
+     * is no branch to name - and an empty list is the honest answer, not a 404.
+     */
+    public function testGetCoursePathsOfCourseOutsideAnyProgram(): void
+    {
+        $course = CourseFactory::createOne(['modules' => []]);
+        ModuleFactory::createOne(['program' => null, 'modules' => [], 'courses' => [$course]]);
+
+        $this->browser()
+            ->get(
+                '/api/courses/' . $course->getId() . '/paths',
+                [
+                    'headers' => [
+                        'Authorization' => 'Bearer ' . $this->token
+                    ]
+                ]
+            )
+            ->assertStatus(200)
+            ->assertJsonMatches('paths', []);
+    }
+
+    public function testGetCoursePathsOfUnknownCourse(): void
+    {
+        $this->browser()
+            ->get(
+                '/api/courses/999999/paths',
+                [
+                    'headers' => [
+                        'Authorization' => 'Bearer ' . $this->token
+                    ]
+                ]
+            )
+            ->assertStatus(404);
+    }
+
+    /**
+     * After a curriculum reform the current code is nearly empty while its predecessor holds
+     * years of exams. Without the count on the link, nothing tells the reader that.
+     */
+    public function testRelatedCoursesCarryTheirDocumentCount(): void
+    {
+        $predecessor = CourseFactory::createOne();
+        $course = CourseFactory::createOne(['oldCourses' => [$predecessor]]);
+        $category = DocumentCategoryFactory::createOne();
+
+        DocumentFactory::createMany(3, [
+            'course' => $predecessor,
+            'category' => $category,
+            'under_review' => false,
+        ]);
+        // Pending uploads are invisible everywhere else, so they must not pad the count here.
+        DocumentFactory::createOne([
+            'course' => $predecessor,
+            'category' => $category,
+            'under_review' => true,
+        ]);
+
+        $this->browser()
+            ->get(
+                '/api/courses/' . $course->getId(),
+                [
+                    'headers' => [
+                        'Authorization' => 'Bearer ' . $this->token
+                    ]
+                ]
+            )
+            ->assertStatus(200)
+            ->assertJsonMatches('oldCourses[0]."@id"', '/api/courses/' . $predecessor->getId())
+            ->assertJsonMatches('oldCourses[0].documentCount', 3);
     }
 }

--- a/backend/tests/Api/DocumentResourceTest.php
+++ b/backend/tests/Api/DocumentResourceTest.php
@@ -126,7 +126,11 @@ class DocumentResourceTest extends ApiTestCase
         $responseDocument = $matchingDocuments[0];
 
         $this->assertSame($document->getName(), $responseDocument['name']);
-        $this->assertNull($responseDocument['contentUrl'] ?? null);
+
+        // What deferring actually saves is the filesystem work: resolving a path, sniffing a
+        // MIME type and reading a size, once per row. The content URL is a string built from
+        // the stored filename, so it stays - a row needs it to offer "open in the browser".
+        $this->assertNotNull($responseDocument['contentUrl'] ?? null);
         $this->assertNull($responseDocument['mimetype'] ?? null);
         $this->assertNull($responseDocument['filename'] ?? null);
         $this->assertNull($responseDocument['fileSize'] ?? null);

--- a/frontend/src/actions/auth.ts
+++ b/frontend/src/actions/auth.ts
@@ -2,6 +2,7 @@
 
 import { COOKIE_NAMES } from '@/utils/cookieNames';
 import { decodeJWT, getUserIdFromJWT, getUserRolesFromJWT, isJWTExpired } from '@/utils/jwt';
+import { refreshTokenExpiry, SESSION_COOKIE_SAME_SITE } from '@/utils/sessionCookies';
 import { captureException } from '@sentry/nextjs';
 import { cookies } from 'next/headers';
 
@@ -89,17 +90,15 @@ export const getActiveJWT = async (): Promise<string | null> => {
     const jwt = cookieStore.get(COOKIE_NAMES.JWT)?.value;
     const refreshToken = cookieStore.get(COOKIE_NAMES.REFRESH_TOKEN)?.value;
 
-    // If no JWT at all, return null
-    if (!jwt) {
-        return null;
-    }
-
-    // If JWT is not expired, return it
-    if (!isJWTExpired(jwt)) {
+    // If JWT is still good, return it
+    if (jwt && !isJWTExpired(jwt)) {
         return jwt;
     }
 
-    // JWT is expired, try to refresh if we have a refresh token
+    // Otherwise the refresh token decides, and it is the only thing that can. The JWT cookie
+    // expires with the token it holds, an hour after it was issued, so coming back the next
+    // day there is no JWT to look at - and bailing on that absence declared the session over
+    // while the refresh token still had weeks left.
     if (!refreshToken) {
         return null;
     }
@@ -173,24 +172,20 @@ export const storeTokensInCookies = async (
         path: '/',
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
-        sameSite: 'strict',
+        sameSite: SESSION_COOKIE_SAME_SITE,
         expires: jwtExpiration,
     });
 
     // Set refresh token cookie if provided
     if (refreshToken) {
-        const refreshExpiration = refreshTokenExpiration
-            ? new Date(refreshTokenExpiration * 1000)
-            : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000); // Default 30 days fallback
-
         cookieStore.set({
             name: COOKIE_NAMES.REFRESH_TOKEN,
             value: refreshToken,
             path: '/',
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
-            sameSite: 'strict',
-            expires: refreshExpiration,
+            sameSite: SESSION_COOKIE_SAME_SITE,
+            expires: refreshTokenExpiry(refreshTokenExpiration),
         });
     }
 };

--- a/frontend/src/app/[locale]/(header-footer)/layout.tsx
+++ b/frontend/src/app/[locale]/(header-footer)/layout.tsx
@@ -1,3 +1,4 @@
+import { CurriculumLocationProvider } from "@/components/curriculum/CurriculumLocationContext";
 import Footer from "@/components/footer/Footer";
 import Header from "@/components/header/Header";
 import Sidebar from "@/components/layout/Sidebar";
@@ -7,29 +8,33 @@ export default function HeaderLayout({ children }: Readonly<{ children: React.Re
     return (
         // The page scrolls as one document so the navy header can stay sticky;
         // the sidebar sticks under it rather than owning its own scroll pane.
-        <div className="flex min-h-full flex-col bg-vtk-paper">
-            {/* Skip to main content link for keyboard users */}
-            <a
-                href="#main-content"
-                className="sr-only focus:not-sr-only focus:fixed focus:top-3 focus:left-3 focus:z-50 focus:rounded-xl focus:bg-vtk-ink focus:px-4 focus:py-2.5 focus:text-sm focus:font-semibold focus:text-white focus:shadow-lg focus:outline-hidden focus:ring-2 focus:ring-vtk-yellow"
-            >
-                Skip to main content
-            </a>
-            <Header />
-            <div className="flex flex-1 items-start">
-                <Sidebar />
-                <main
-                    id="main-content"
-                    tabIndex={-1}
-                    className="min-w-0 flex-1 focus:outline-hidden"
-                    style={{
-                        '--vtk-loading-min-height': 'calc(100dvh - var(--vtk-header-height))'
-                    } as React.CSSProperties}
+        // The provider sits above both so the sidebar's folder tree can follow the page
+        // below it without re-fetching what that page already loaded.
+        <CurriculumLocationProvider>
+            <div className="flex min-h-full flex-col bg-vtk-paper">
+                {/* Skip to main content link for keyboard users */}
+                <a
+                    href="#main-content"
+                    className="sr-only focus:not-sr-only focus:fixed focus:top-3 focus:left-3 focus:z-50 focus:rounded-xl focus:bg-vtk-ink focus:px-4 focus:py-2.5 focus:text-sm focus:font-semibold focus:text-white focus:shadow-lg focus:outline-hidden focus:ring-2 focus:ring-vtk-yellow"
                 >
-                    {children}
-                </main>
+                    Skip to main content
+                </a>
+                <Header />
+                <div className="flex flex-1 items-start">
+                    <Sidebar />
+                    <main
+                        id="main-content"
+                        tabIndex={-1}
+                        className="min-w-0 flex-1 focus:outline-hidden"
+                        style={{
+                            '--vtk-loading-min-height': 'calc(100dvh - var(--vtk-header-height))'
+                        } as React.CSSProperties}
+                    >
+                        {children}
+                    </main>
+                </div>
+                <Footer />
             </div>
-            <Footer />
-        </div>
+        </CurriculumLocationProvider>
     );
 }

--- a/frontend/src/components/coursepage/CourseDocumentsContent.tsx
+++ b/frontend/src/components/coursepage/CourseDocumentsContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Loading from '@/app/[locale]/loading';
+import { usePublishCurriculumLocation } from '@/components/curriculum/CurriculumLocationContext';
 import DocumentCategoryPage from '@/components/documentcategorypage/DocumentCategoryPage';
 import { useApi } from '@/hooks/useApi';
 import type { Course, DocumentCategory } from '@/types/entities';
@@ -52,6 +53,9 @@ export default function CourseDocumentsContent({ courseId, categoryId }: CourseD
 
         getCategory();
     }, [categoryId, request, currentLocale]);
+
+    // Feeds the folder tree and the breadcrumb in the layout, which cannot read this route.
+    usePublishCurriculumLocation({ course: course ?? undefined, category: category ?? undefined });
 
     useEffect(() => {
         const courseName = localizedCourseName(course, currentLocale);

--- a/frontend/src/components/coursepage/CoursePage.tsx
+++ b/frontend/src/components/coursepage/CoursePage.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import Loading from '@/app/[locale]/loading';
+import CoursePlacement from "@/components/curriculum/CoursePlacement";
+import { usePublishCurriculumLocation } from "@/components/curriculum/CurriculumLocationContext";
 import CommentCategories from "@/components/coursepage/comment/CommentCategories";
 import DocumentSections from "@/components/coursepage/DocumentSections";
 import ProfessorDiv from "@/components/coursepage/ProfessorDiv";
@@ -45,6 +47,9 @@ export default function CoursePage() {
             getCourse();
         }
     }, [courseId, userLoading, request]);
+
+    // Feeds the folder tree and the breadcrumb in the layout, which cannot read this route.
+    usePublishCurriculumLocation({ course: course ?? undefined });
 
     const courseName = localizedCourseName(course, i18n.language);
 
@@ -135,6 +140,8 @@ export default function CoursePage() {
                     </div>
 
                     <RelatedCourses course={course} />
+
+                    <CoursePlacement />
                 </PageHead>
 
                 {/* Documents */}

--- a/frontend/src/components/coursepage/RelatedCourses.tsx
+++ b/frontend/src/components/coursepage/RelatedCourses.tsx
@@ -62,6 +62,15 @@ export default function RelatedCourses({ course }: RelatedCoursesProps) {
                             {localizedCourseName(related, i18n.language) && (
                                 <span className="ml-1.5">{localizedCourseName(related, i18n.language)}</span>
                             )}
+                            {/* How much is actually over there. A reform leaves the new code
+                                nearly empty while the old one holds a decade of exams, and
+                                without a number the link reads as a footnote rather than as
+                                the place the material still lives. */}
+                            {related.documentCount !== undefined && related.documentCount > 0 && (
+                                <span className="ml-1.5 text-vtk-muted">
+                                    {t('course-page.related.documents', { count: related.documentCount })}
+                                </span>
+                            )}
                         </Link>
                     ))}
                 </div>

--- a/frontend/src/components/courses/CourseRow.tsx
+++ b/frontend/src/components/courses/CourseRow.tsx
@@ -6,6 +6,7 @@ import { useProgramLanguage } from '@/components/courses/ProgramLanguageContext'
 import { useApi } from "@/hooks/useApi";
 import type { Course } from '@/types/entities';
 import { convertToCourse } from "@/utils/convertToEntity";
+import { rememberBranch } from '@/utils/curriculumBranch';
 import { captureException } from '@sentry/nextjs';
 import Link from "next/link";
 import { memo, useEffect, useState } from 'react';
@@ -18,6 +19,11 @@ interface CourseRowProps {
     course: Course;
     highlightMatch?: boolean;
     isFirstRow?: boolean;
+    /**
+     * The module this row is listed under. Half the courses are shared between programmes, so
+     * without it the course page would have to guess which of them the reader came through.
+     */
+    moduleId?: number;
 }
 
 function hasCourseRowData(course: Course): boolean {
@@ -31,6 +37,7 @@ export const CourseRow = memo(({
     course: initialCourse,
     highlightMatch = false,
     isFirstRow = false,
+    moduleId,
 }: CourseRowProps) => {
     const { i18n } = useTranslation();
     // Inside the curriculum navigator the programme decides the title language; elsewhere there is
@@ -128,7 +135,14 @@ export const CourseRow = memo(({
                         {content.name}
                     </div>
                 ) : (
-                    <Link href={`/course/${course.id}`} className="hover:text-vtk-navy hover:underline text-sm text-vtk-body rounded-xs focus:outline-hidden focus-visible:ring-2 focus-visible:ring-vtk-navy focus-visible:ring-offset-1">
+                    <Link
+                        href={`/course/${course.id}`}
+                        // The branch the reader walked, so the course page's breadcrumb and
+                        // folder tree name the programme they actually came from rather than
+                        // whichever one the course happens to be listed under first.
+                        onClick={moduleId === undefined ? undefined : () => rememberBranch(course.id, moduleId)}
+                        className="hover:text-vtk-navy hover:underline text-sm text-vtk-body rounded-xs focus:outline-hidden focus-visible:ring-2 focus-visible:ring-vtk-navy focus-visible:ring-offset-1"
+                    >
                         {content.name}
                     </Link>
                 )}

--- a/frontend/src/components/courses/CurriculumNavigator.tsx
+++ b/frontend/src/components/courses/CurriculumNavigator.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Loading from '@/app/[locale]/loading';
+import { CurriculumOpenStateProvider } from '@/components/courses/CurriculumOpenState';
 import CurriculumSearchBar, { SearchFilters } from '@/components/courses/CurriculumSearchBar';
 import ProgramNode from '@/components/courses/ProgramNode';
 import DynamicBreadcrumb from '@/components/ui/DynamicBreadcrumb';
@@ -246,16 +247,20 @@ export default function CurriculumNavigator() {
 
       {!programError && (programs.length > 0 ? (
         <div className="curriculum-tree mt-5 grid gap-2.5">
-          {programs.map((program) => (
-            <ProgramNode
-              key={`${program.id}:${hasActiveSearch ? JSON.stringify(searchFilters) : 'browse'}`}
-              program={program}
-              autoExpand={hasActiveSearch}
-              searchFilters={searchFilters}
-              favoriteCourses={user?.favoriteCourses}
-              focus={focus}
-            />
-          ))}
+          {/* The open branches live in the URL, so leaving for a course and pressing back
+              returns to the tree as it was rather than to a collapsed one. */}
+          <CurriculumOpenStateProvider>
+            {programs.map((program) => (
+              <ProgramNode
+                key={`${program.id}:${hasActiveSearch ? JSON.stringify(searchFilters) : 'browse'}`}
+                program={program}
+                autoExpand={hasActiveSearch}
+                searchFilters={searchFilters}
+                favoriteCourses={user?.favoriteCourses}
+                focus={focus}
+              />
+            ))}
+          </CurriculumOpenStateProvider>
         </div>
       ) : (
         <div className="vtk-panel vtk-empty mt-5">

--- a/frontend/src/components/courses/CurriculumOpenState.tsx
+++ b/frontend/src/components/courses/CurriculumOpenState.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+
+/**
+ * More than this and the URL stops being something you can paste into a chat. Nobody opens
+ * sixty branches on purpose, so the cap only ever bites on a runaway, and it drops the
+ * oldest entries rather than refusing the newest click.
+ */
+const MAX_REMEMBERED_NODES = 60;
+
+const PARAM = 'open';
+
+interface CurriculumOpenStateValue {
+    isOpen: (key: string) => boolean;
+    setOpen: (key: string, open: boolean) => void;
+}
+
+const NOOP: CurriculumOpenStateValue = {
+    isOpen: () => false,
+    setOpen: () => { },
+};
+
+const CurriculumOpenStateContext = createContext<CurriculumOpenStateValue>(NOOP);
+
+/** The key a node is remembered under: `p12` for a program, `m34` for a module. */
+export function programKey(id: number): string {
+    return `p${id}`;
+}
+
+export function moduleKey(id: number): string {
+    return `m${id}`;
+}
+
+/**
+ * Remembers which branches of the curriculum tree the reader opened, in the URL.
+ *
+ * Walking down four levels and clicking a course used to be a one-way trip: coming back
+ * landed on a fully collapsed tree and the whole descent had to be repeated. The open
+ * branches live in the query string, so the browser's own back button restores them - and a
+ * link to "here is where that course sits" becomes something you can paste to someone else.
+ *
+ * `replace` rather than `push`: opening a folder is not a destination, and every toggle
+ * pushing an entry would turn one back press into ten.
+ */
+export function CurriculumOpenStateProvider({ children }: { children: ReactNode }) {
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    // Seeded from the URL, then owned here: reading `searchParams` on every render would make
+    // each toggle wait for the router round-trip before the branch visibly opens.
+    const [openKeys, setOpenKeys] = useState<string[]>(
+        () => searchParams.get(PARAM)?.split(',').filter(Boolean) ?? []
+    );
+
+    const setOpen = useCallback((key: string, open: boolean) => {
+        const withoutKey = openKeys.filter((existing) => existing !== key);
+        const next = open ? [...withoutKey, key].slice(-MAX_REMEMBERED_NODES) : withoutKey;
+
+        setOpenKeys(next);
+
+        // Read the live query string rather than rebuilding from `searchParams`, so a search
+        // or a ?module= deep link already in the URL survives a folder being opened.
+        const params = new URLSearchParams(window.location.search);
+        if (next.length > 0) {
+            params.set(PARAM, next.join(','));
+        } else {
+            params.delete(PARAM);
+        }
+
+        const query = params.toString();
+        router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    }, [openKeys, router, pathname]);
+
+    const value = useMemo(() => {
+        const open = new Set(openKeys);
+        return { isOpen: (key: string) => open.has(key), setOpen };
+    }, [openKeys, setOpen]);
+
+    return (
+        <CurriculumOpenStateContext.Provider value={value}>
+            {children}
+        </CurriculumOpenStateContext.Provider>
+    );
+}
+
+export function useCurriculumOpenState(): CurriculumOpenStateValue {
+    return useContext(CurriculumOpenStateContext);
+}

--- a/frontend/src/components/courses/ModuleNode.tsx
+++ b/frontend/src/components/courses/ModuleNode.tsx
@@ -1,5 +1,6 @@
 import { CourseRow } from '@/components/courses/CourseRow';
 import { CourseTableHeader } from '@/components/courses/CourseTableHeader';
+import { moduleKey, useCurriculumOpenState } from '@/components/courses/CurriculumOpenState';
 import { SearchFilters } from '@/components/courses/CurriculumSearchBar';
 import DownloadButton from '@/components/ui/DownloadButton';
 import FavoriteButton from '@/components/ui/FavoriteButton';
@@ -33,7 +34,11 @@ const ModuleNode = ({
 }: ModuleNodeProps) => {
     const { t } = useTranslation();
     const { request, loading, error } = useApi<unknown>();
-    const [expanded, setExpanded] = useState(false);
+    // Seeded from the branches the URL says are open, so coming back from a course lands on
+    // the tree the reader left rather than on a collapsed one.
+    const openState = useCurriculumOpenState();
+    const nodeKey = moduleKey(initialModule.id);
+    const [expanded, setExpanded] = useState(() => openState.isOpen(nodeKey));
     const [module, setModule] = useState<Module>(initialModule);
     const [loaded, setLoaded] = useState(
         () => Array.isArray(initialModule.courses) && Array.isArray(initialModule.modules)
@@ -54,14 +59,20 @@ const ModuleNode = ({
     }, [initialModule.id, loaded, request]);
 
     const toggleExpanded = () => {
-        if (expanded) {
-            setExpanded(false);
-            return;
-        }
-
-        setExpanded(true);
-        void loadModule();
+        const next = !expanded;
+        setExpanded(next);
+        // Only a deliberate toggle is written to the URL; see ProgramNode for why.
+        openState.setOpen(nodeKey, next);
     };
+
+    // Whichever way the node ended up open - a click, a search, a deep link, or the branch
+    // restored from the URL - it needs its children. loadModule is a no-op once loaded.
+    useEffect(() => {
+        if (expanded) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            void loadModule();
+        }
+    }, [expanded, loadModule]);
 
     // Get search query
     const searchQuery = searchFilters?.query?.toLowerCase();
@@ -79,9 +90,8 @@ const ModuleNode = ({
         if (autoExpand && hasChildMatches) {
             // eslint-disable-next-line react-hooks/set-state-in-effect
             setExpanded(true);
-            void loadModule();
         }
-    }, [autoExpand, hasChildMatches, loadModule]);
+    }, [autoExpand, hasChildMatches]);
 
     // Calculate if any child items match
     const getChildMatches = (): {
@@ -107,9 +117,8 @@ const ModuleNode = ({
         if (onFocusPath) {
             // eslint-disable-next-line react-hooks/set-state-in-effect
             setExpanded(true);
-            void loadModule();
         }
-    }, [onFocusPath, loadModule]);
+    }, [onFocusPath]);
 
     // Once only: re-scrolling on every render would fight the reader for the viewport.
     const headerRef = useRef<HTMLDivElement>(null);
@@ -182,6 +191,7 @@ const ModuleNode = ({
                                                 course={course}
                                                 highlightMatch={!!searchQuery && courseMatchesText(course, searchQuery)}
                                                 isFirstRow={index === 0}
+                                                moduleId={module.id}
                                             />
                                         ))}
                                     </div>

--- a/frontend/src/components/courses/ProgramNode.tsx
+++ b/frontend/src/components/courses/ProgramNode.tsx
@@ -1,4 +1,5 @@
 import { SearchFilters } from '@/components/courses/CurriculumSearchBar';
+import { programKey, useCurriculumOpenState } from '@/components/courses/CurriculumOpenState';
 import ModuleNode from '@/components/courses/ModuleNode';
 import { ProgramLanguageProvider } from '@/components/courses/ProgramLanguageContext';
 import DownloadButton from '@/components/ui/DownloadButton';
@@ -33,7 +34,11 @@ const ProgramNode = ({
 }: ProgramNodeProps) => {
   const { t } = useTranslation();
   const { request, loading, error } = useApi<unknown>();
-  const [expanded, setExpanded] = useState(false);
+  // Seeded from the branches the URL says are open, so coming back from a course lands on the
+  // tree the reader left rather than on a collapsed one.
+  const openState = useCurriculumOpenState();
+  const nodeKey = programKey(initialProgram.id);
+  const [expanded, setExpanded] = useState(() => openState.isOpen(nodeKey));
   const [program, setProgram] = useState(initialProgram);
   const [loaded, setLoaded] = useState(() => Array.isArray(initialProgram.modules));
   const requestInFlight = useRef(false);
@@ -52,14 +57,22 @@ const ProgramNode = ({
   }, [initialProgram.id, loaded, request]);
 
   const toggleExpanded = () => {
-    if (expanded) {
-      setExpanded(false);
-      return;
-    }
-
-    setExpanded(true);
-    void loadProgram();
+    const next = !expanded;
+    setExpanded(next);
+    // Only a deliberate toggle is written to the URL. Search and deep links open branches on
+    // the reader's behalf; recording those too would fill the query string with state nobody
+    // chose and that the search or the link already reproduces.
+    openState.setOpen(nodeKey, next);
   };
+
+  // Whichever way the node ended up open - a click, a search, a deep link, or the branch
+  // restored from the URL - it needs its children. loadProgram is a no-op once loaded.
+  useEffect(() => {
+    if (expanded) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      void loadProgram();
+    }
+  }, [expanded, loadProgram]);
 
   // Get search query
   const searchQuery = searchFilters?.query?.toLowerCase();
@@ -77,9 +90,8 @@ const ProgramNode = ({
     if (autoExpand && hasChildMatches) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setExpanded(true);
-      void loadProgram();
     }
-  }, [autoExpand, hasChildMatches, loadProgram]);
+  }, [autoExpand, hasChildMatches]);
 
   // A deep link names this program, either as its destination or as the way down to a module.
   const onFocusPath = focus?.programId === program.id;
@@ -89,9 +101,8 @@ const ProgramNode = ({
     if (onFocusPath) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setExpanded(true);
-      void loadProgram();
     }
-  }, [onFocusPath, loadProgram]);
+  }, [onFocusPath]);
 
   // Once only: re-scrolling on every render would fight the reader for the viewport.
   const headerRef = useRef<HTMLDivElement>(null);

--- a/frontend/src/components/curriculum/CoursePlacement.tsx
+++ b/frontend/src/components/curriculum/CoursePlacement.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useCurriculumLocation } from '@/components/curriculum/CurriculumLocationContext';
+import { ChevronRight, Network } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * The other programmes a course is taught in.
+ *
+ * Half the engineering courses are shared, so "am I looking at the right Beton?" is a real
+ * question and the breadcrumb can only answer it for one branch at a time. Picking another
+ * one here re-points the breadcrumb and the folder tree at that programme instead of
+ * navigating away, because the course, its documents and its comments are the same either way
+ * - only the surroundings differ.
+ */
+export default function CoursePlacement() {
+    const { t } = useTranslation();
+    const { paths, activePath, chooseBranch } = useCurriculumLocation();
+
+    // With one placement the breadcrumb already says everything there is to say.
+    if (paths.length < 2) {
+        return null;
+    }
+
+    return (
+        <div className="mt-5">
+            <div className="vtk-label mb-2 flex items-center gap-1.5 text-vtk-muted">
+                <Network size={14} aria-hidden="true" />
+                {t('course-page.placement.label')}
+            </div>
+            <div className="flex flex-wrap gap-2">
+                {paths.map((path) => {
+                    const leafModuleId = path.modules.at(-1)?.id;
+                    const isActive = path === activePath;
+
+                    return (
+                        <button
+                            key={`${path.program.id}:${leafModuleId}`}
+                            type="button"
+                            onClick={() => leafModuleId !== undefined && chooseBranch(leafModuleId)}
+                            aria-pressed={isActive}
+                            className={`vtk-badge flex items-center gap-1 text-left transition-colors focus:outline-hidden focus-visible:ring-2 focus-visible:ring-vtk-navy focus-visible:ring-offset-1 ${isActive
+                                ? 'vtk-badge-accent'
+                                : 'vtk-badge-muted hover:border-vtk-line-2 hover:bg-vtk-surface hover:text-vtk-ink'
+                                }`}
+                        >
+                            <span>{path.program.name}</span>
+                            {path.modules.map((module) => (
+                                <span key={module.id} className="flex items-center gap-1 text-vtk-muted">
+                                    <ChevronRight size={11} aria-hidden="true" />
+                                    <span>{module.name}</span>
+                                </span>
+                            ))}
+                        </button>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/curriculum/CurriculumLocationContext.tsx
+++ b/frontend/src/components/curriculum/CurriculumLocationContext.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useCoursePaths } from '@/hooks/useCoursePaths';
+import type { Course, CurriculumPath, Document, DocumentCategory } from '@/types/entities';
+import { rememberBranch, selectPath } from '@/utils/curriculumBranch';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+
+/**
+ * Where in the curriculum the reader currently is: the course page they opened, and the
+ * category and document below it once they go deeper.
+ */
+export interface CurriculumLocation {
+    course?: Course;
+    category?: DocumentCategory;
+    document?: Document;
+}
+
+interface CurriculumLocationValue extends CurriculumLocation {
+    /** Every placement of the current course; empty while loading and for courses no program reaches. */
+    paths: CurriculumPath[];
+    /** The one placement the breadcrumb and the folder tree agree to show. */
+    activePath: CurriculumPath | null;
+    pathsLoading: boolean;
+    /** Switch the shown placement to the branch ending in this module. */
+    chooseBranch: (leafModuleId: number) => void;
+    setLocation: (location: CurriculumLocation) => void;
+}
+
+const CurriculumLocationContext = createContext<CurriculumLocationValue | null>(null);
+
+const EMPTY: CurriculumLocationValue = {
+    paths: [],
+    activePath: null,
+    pathsLoading: false,
+    chooseBranch: () => { },
+    setLocation: () => { },
+};
+
+/**
+ * Lets the folder tree and the breadcrumbs follow the page without each of them fetching the
+ * same thing. The tree lives in the layout, above every route, so it cannot read a route's
+ * params; the pages already hold the course, category and document and simply hand them over,
+ * and the placement lookup that both need happens here, once.
+ */
+export function CurriculumLocationProvider({ children }: { children: ReactNode }) {
+    const [location, setLocation] = useState<CurriculumLocation>({});
+    const { paths, loading: pathsLoading } = useCoursePaths(location.course?.id);
+    const courseId = location.course?.id;
+
+    // A course shared between programmes can be looked at from any of them; this is the one
+    // the reader picked on this page, which outranks the branch they walked to get here.
+    const [chosenBranch, setChosenBranch] = useState<number | null>(null);
+    useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setChosenBranch(null);
+    }, [courseId]);
+
+    const activePath = useMemo(() => {
+        if (courseId === undefined) return null;
+
+        if (chosenBranch !== null) {
+            const chosen = paths.find((path) => path.modules.some((module) => module.id === chosenBranch));
+            if (chosen) return chosen;
+        }
+
+        return selectPath(paths, courseId);
+    }, [paths, courseId, chosenBranch]);
+
+    const chooseBranch = useCallback((leafModuleId: number) => {
+        if (courseId !== undefined) {
+            rememberBranch(courseId, leafModuleId);
+        }
+        setChosenBranch(leafModuleId);
+    }, [courseId]);
+
+    const value = useMemo(
+        () => ({ ...location, paths, activePath, pathsLoading, chooseBranch, setLocation }),
+        [location, paths, activePath, pathsLoading, chooseBranch]
+    );
+
+    return (
+        <CurriculumLocationContext.Provider value={value}>
+            {children}
+        </CurriculumLocationContext.Provider>
+    );
+}
+
+export function useCurriculumLocation(): CurriculumLocationValue {
+    return useContext(CurriculumLocationContext) ?? EMPTY;
+}
+
+/**
+ * Publishes the page's position to the tree, and clears it on unmount so a page with no
+ * curriculum position (the FAQ, the account page) does not inherit the last one.
+ */
+export function usePublishCurriculumLocation(location: CurriculumLocation): void {
+    const context = useContext(CurriculumLocationContext);
+    const setLocation = context?.setLocation;
+    const { course, category, document } = location;
+
+    useEffect(() => {
+        if (!setLocation) return;
+
+        setLocation({ course, category, document });
+
+        return () => setLocation({});
+    }, [setLocation, course, category, document]);
+}

--- a/frontend/src/components/curriculum/CurriculumTree.tsx
+++ b/frontend/src/components/curriculum/CurriculumTree.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useCurriculumLocation } from '@/components/curriculum/CurriculumLocationContext';
+import { HydraCollection, useApi } from '@/hooks/useApi';
+import { useSiblingDocuments } from '@/hooks/useSiblingDocuments';
+import type { Course, DocumentCategory, Module } from '@/types/entities';
+import { convertToDocumentCategory, convertToModule } from '@/utils/convertToEntity';
+import { localizedCourseName } from '@/utils/courseName';
+import { rememberBranch } from '@/utils/curriculumBranch';
+import { File, FolderClosed, FolderOpen, GraduationCap, LoaderCircle } from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Indentation is capped so a deeply nested branch does not push its own leaves off a 288px
+ * rail. Past the cap the rows sit at the same depth and the tree relies on the icons and the
+ * highlight to say where the reader is.
+ */
+const MAX_INDENT_LEVEL = 4;
+
+interface TreeRowProps {
+    label: string;
+    href: string;
+    level: number;
+    icon: 'program' | 'folder' | 'course' | 'document';
+    open?: boolean;
+    active?: boolean;
+    badge?: number;
+    onClick?: () => void;
+}
+
+function TreeRow({ label, href, level, icon, open = false, active = false, badge, onClick }: TreeRowProps) {
+    const rowRef = useRef<HTMLAnchorElement>(null);
+    const scrolled = useRef(false);
+
+    // A course with many neighbours or a folder with a decade of scans puts the active row
+    // below the fold. Once only: re-scrolling on every render would fight the reader.
+    useEffect(() => {
+        if (active && !scrolled.current) {
+            scrolled.current = true;
+            rowRef.current?.scrollIntoView({ block: 'nearest' });
+        }
+    }, [active]);
+
+    const Icon = icon === 'program'
+        ? GraduationCap
+        : icon === 'document'
+            ? File
+            : open ? FolderOpen : FolderClosed;
+
+    return (
+        <Link
+            ref={rowRef}
+            href={href}
+            onClick={onClick}
+            aria-current={active ? 'page' : undefined}
+            title={label}
+            style={{ paddingLeft: `${0.5 + Math.min(level, MAX_INDENT_LEVEL) * 0.75}rem` }}
+            className={`flex items-center gap-2 rounded-lg py-1.5 pr-2 text-[13px] leading-snug transition-colors focus:outline-hidden focus-visible:ring-2 focus-visible:ring-vtk-navy ${active
+                ? 'bg-vtk-paper-2 font-semibold text-vtk-ink shadow-[inset_2px_0_0_var(--yellow)]'
+                : 'text-vtk-body hover:bg-vtk-paper-2 hover:text-vtk-ink'
+                }`}
+        >
+            <Icon size={14} className="shrink-0 text-vtk-muted" aria-hidden="true" />
+            <span className="min-w-0 flex-1 truncate">{label}</span>
+            {badge !== undefined && badge > 0 && (
+                <span className="shrink-0 text-[11px] tabular-nums text-vtk-muted">{badge}</span>
+            )}
+        </Link>
+    );
+}
+
+/**
+ * The folder tree the old Burgieclan had down the side, rebuilt on top of the curriculum:
+ * programme → modules → courses → categories → documents, opened to wherever the reader is
+ * and showing the neighbours at every level.
+ *
+ * It answers the two things the tabbed navigator could not. Which branch am I in - a course
+ * page reached from a search or a favourite carries no programme in its URL, so the page had
+ * no way of saying whether this was the right "Beton" out of three. And where do I go next -
+ * stepping from exercise session 1 to 2 meant walking back up through the folder every time.
+ *
+ * Everything below the programme is a link into a real page, so nothing here is a dead end:
+ * a programme or module row opens the navigator on that node.
+ */
+export default function CurriculumTree() {
+    const { t, i18n } = useTranslation();
+    const { course, category, document, paths, activePath, pathsLoading } = useCurriculumLocation();
+
+    // Sibling courses come from the module that teaches this one; sibling categories and
+    // documents only matter once the reader is inside a folder, so neither is fetched on a
+    // course page - the page body already lists the categories as cards there.
+    const leafModuleId = activePath?.modules.at(-1)?.id;
+    const siblingCourses = useModuleCourses(leafModuleId);
+    const categories = useDocumentCategories(category !== undefined);
+    const { documents: siblingDocuments } = useSiblingDocuments(
+        document ? course?.id : undefined,
+        document ? category?.id : undefined
+    );
+
+    if (!course) {
+        return null;
+    }
+
+    const countFor = (item: DocumentCategory) => course.documentCounts?.[item.id] ?? 0;
+
+    // Until the module answers, the reader's own course stands in for the list of neighbours -
+    // and it stays in it if the module somehow comes back without it, because a tree that does
+    // not contain where you are is worse than no tree.
+    const courseRows = siblingCourses?.some((sibling) => sibling.id === course.id)
+        ? siblingCourses
+        : [course];
+
+    return (
+        <nav aria-label={t('curriculum-tree.label')} className="flex min-h-0 flex-col">
+            <div className="vtk-label px-2.5 pb-1.5">{t('curriculum-tree.label')}</div>
+
+            {pathsLoading && paths.length === 0 ? (
+                <div className="flex justify-center py-4">
+                    <LoaderCircle className="animate-spin text-vtk-muted" size={16} />
+                </div>
+            ) : (
+                <div className="flex flex-col">
+                    {activePath ? (
+                        <>
+                            <TreeRow
+                                label={activePath.program.name ?? ''}
+                                href={`/courses?program=${activePath.program.id}`}
+                                level={0}
+                                icon="program"
+                                open
+                            />
+                            {activePath.modules.map((module, index) => (
+                                <TreeRow
+                                    key={module.id}
+                                    label={module.name ?? ''}
+                                    href={`/courses?module=${module.id}`}
+                                    level={index + 1}
+                                    icon="folder"
+                                    open
+                                />
+                            ))}
+                        </>
+                    ) : (
+                        // A course no programme reaches still deserves a way back up.
+                        <TreeRow label={t('courses')} href="/courses" level={0} icon="folder" open />
+                    )}
+
+                    {courseRows.map((sibling) => {
+                        const isCurrent = sibling.id === course.id;
+                        const courseLevel = activePath ? activePath.modules.length + 1 : 1;
+
+                        return (
+                            <div key={sibling.id} className="contents">
+                                <TreeRow
+                                    label={localizedCourseName(sibling, i18n.language) ?? sibling.code ?? ''}
+                                    href={`/course/${sibling.id}`}
+                                    level={courseLevel}
+                                    icon="course"
+                                    open={isCurrent && categories.length > 0}
+                                    active={isCurrent && !category}
+                                    // Stepping sideways to a neighbour keeps the branch: without this the
+                                    // next page would fall back to that course's first placement, which
+                                    // for a shared course is a different programme than the one on screen.
+                                    onClick={leafModuleId ? () => rememberBranch(sibling.id, leafModuleId) : undefined}
+                                />
+
+                                {isCurrent && categories.map((item) => {
+                                    const isCurrentCategory = item.id === category?.id;
+
+                                    return (
+                                        <div key={item.id} className="contents">
+                                            <TreeRow
+                                                label={item.name ?? ''}
+                                                href={`/course/${course.id}/documents/category/${item.id}`}
+                                                level={courseLevel + 1}
+                                                icon="folder"
+                                                open={isCurrentCategory}
+                                                active={isCurrentCategory && !document}
+                                                badge={countFor(item)}
+                                            />
+
+                                            {isCurrentCategory && siblingDocuments.map((file) => (
+                                                <TreeRow
+                                                    key={file.id}
+                                                    label={file.name ?? file.filename ?? ''}
+                                                    href={`/document/${file.id}`}
+                                                    level={courseLevel + 2}
+                                                    icon="document"
+                                                    active={file.id === document?.id}
+                                                />
+                                            ))}
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </nav>
+    );
+}
+
+/** The courses taught by one module, or null while the module has not been loaded. */
+function useModuleCourses(moduleId?: number): Course[] | null {
+    const { request } = useApi<unknown>();
+    const [courses, setCourses] = useState<Course[] | null>(null);
+
+    useEffect(() => {
+        if (moduleId === undefined) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            setCourses(null);
+            return;
+        }
+
+        let cancelled = false;
+
+        const fetchModule = async () => {
+            const data = await request('GET', `/api/modules/${moduleId}`);
+            if (cancelled) return;
+
+            const loaded: Module | null = data ? convertToModule(data) : null;
+            setCourses(loaded?.courses ?? null);
+        };
+
+        void fetchModule();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [moduleId, request]);
+
+    return courses;
+}
+
+/**
+ * The document categories, in the reader's language. Fetched only when the tree actually
+ * draws them - on a course page the page body already lists them as cards.
+ */
+function useDocumentCategories(enabled: boolean): DocumentCategory[] {
+    const { request } = useApi<HydraCollection<unknown>>();
+    const [categories, setCategories] = useState<DocumentCategory[]>([]);
+    const { i18n } = useTranslation();
+    const language = i18n.language;
+
+    useEffect(() => {
+        if (!enabled) return;
+
+        let cancelled = false;
+
+        const fetchCategories = async () => {
+            const result = await request('GET', `/api/document_categories?lang=${language}`);
+            if (cancelled) return;
+
+            const members = result?.['hydra:member'];
+            setCategories(Array.isArray(members) ? members.map(convertToDocumentCategory) : []);
+        };
+
+        void fetchCategories();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [enabled, language, request]);
+
+    return categories;
+}

--- a/frontend/src/components/document/DocumentPreview.tsx
+++ b/frontend/src/components/document/DocumentPreview.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { usePublishCurriculumLocation } from "@/components/curriculum/CurriculumLocationContext";
 import DocumentCommentSection from "@/components/document/DocumentCommentSection";
 import DocumentInfoField from "@/components/document/DocumentInfoField";
+import DocumentSiblingNav from "@/components/document/DocumentSiblingNav";
 import UnderReviewBox from "@/components/document/UnderReviewBox";
 import ErrorPage from "@/components/error/ErrorPage";
 import LoadingPage from "@/components/loading/LoadingPage";
@@ -16,6 +18,7 @@ import { useApi } from "@/hooks/useApi";
 import type { Document } from "@/types/entities";
 import { convertToDocument } from "@/utils/convertToEntity";
 import { formatFileSize } from "@/utils/fileSize";
+import { inlineUrl, previewKindFor } from "@/utils/previewableFile";
 import { Calendar, ChartPie, CircleUser, ExternalLink, File, Package, PenLine } from "lucide-react";
 import dynamic from "next/dynamic";
 import { useEffect, useRef, useState } from "react";
@@ -55,6 +58,13 @@ export default function DocumentPreview({ id }: { id: string }) {
         logDocumentView(id);
     }, [id]);
 
+    // Feeds the folder tree and the breadcrumb in the layout, which cannot read this route.
+    usePublishCurriculumLocation({
+        course: document?.course,
+        category: document?.category,
+        document: document ?? undefined,
+    });
+
     // Set window title based on document name
     useEffect(() => {
         if (document?.name) {
@@ -83,15 +93,14 @@ export default function DocumentPreview({ id }: { id: string }) {
 
     if (!document) return null;
 
-    const isPdf = document.mimetype === "application/pdf" ||
-        document.filename?.toLowerCase().endsWith('.pdf') ||
-        document.contentUrl?.toLowerCase().endsWith('.pdf');
-    const isImage = document.mimetype?.startsWith("image/") ||
-        ['.png', '.jpg', '.jpeg', '.gif', '.webp'].some(ext =>
-            document.filename?.toLowerCase().endsWith(ext) ||
-            document.contentUrl?.toLowerCase().endsWith(ext)
-        );
-    const canPreview = document.contentUrl && (isPdf || isImage);
+    // Which types render in-browser lives in one place now, shared with the document rows
+    // and kept in step with the backend list that decides what ?inline=1 actually serves.
+    const previewKind = previewKindFor(document.filename ?? document.contentUrl, document.mimetype);
+    const isPdf = previewKind === 'pdf';
+    const isImage = previewKind === 'image';
+    // Null when the file is not one the browser can draw, which is also the only case where
+    // the "open in a new tab" control has nothing to point at.
+    const inlineHref = document.contentUrl && previewKind ? inlineUrl(document.contentUrl) : null;
 
     return (
         <div className="vtk-shell pb-16">
@@ -146,15 +155,16 @@ export default function DocumentPreview({ id }: { id: string }) {
                             objectId={Number(id)}
                             disabled={!user}
                         />
+                        <DocumentSiblingNav document={document} />
                         <div className="flex items-center gap-2">
                             <DownloadSingleDocumentButton
                                 document={document}
                                 fileSize={document.fileSize ? formatFileSize(document.fileSize) : undefined}
                                 disabled={!user}
                             />
-                            {canPreview && (
+                            {inlineHref && (
                                 <a
-                                    href={`${document.contentUrl}?inline=1`}
+                                    href={inlineHref}
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     className="vtk-btn vtk-btn-ghost p-2"
@@ -181,7 +191,7 @@ export default function DocumentPreview({ id }: { id: string }) {
                             // and never a candidate for the optimizer's cache.
                             // eslint-disable-next-line @next/next/no-img-element
                             <img
-                                src={`${document.contentUrl}?inline=1`}
+                                src={inlineUrl(document.contentUrl)}
                                 alt={document.name}
                                 className="max-h-[75vh] max-w-full rounded shadow-sm object-contain"
                             />

--- a/frontend/src/components/document/DocumentSiblingNav.tsx
+++ b/frontend/src/components/document/DocumentSiblingNav.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useSiblingDocuments } from '@/hooks/useSiblingDocuments';
+import type { Document } from '@/types/entities';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Step to the previous or next document in the same folder.
+ *
+ * Reading exercise session 1 of 6 used to mean going back to the category page for every next
+ * file. The order is the category page's own - newest academic year first, name as the
+ * tiebreaker - so "next" means what the list said it would.
+ */
+export default function DocumentSiblingNav({ document }: { document: Document }) {
+    const { t } = useTranslation();
+    const { documents } = useSiblingDocuments(document.course?.id, document.category?.id);
+
+    const index = documents.findIndex((sibling) => sibling.id === document.id);
+
+    // Nothing to step through, or the document fell outside the window the hook fetches.
+    if (index === -1 || documents.length < 2) {
+        return null;
+    }
+
+    const previous = documents[index - 1];
+    const next = documents[index + 1];
+
+    const arrow = 'vtk-icon-button h-8 w-8';
+    const disabled = 'pointer-events-none opacity-40';
+
+    return (
+        <div className="flex items-center gap-1.5">
+            {previous ? (
+                <Link
+                    href={`/document/${previous.id}`}
+                    className={arrow}
+                    title={previous.name ?? t('document.siblings.previous')}
+                    aria-label={t('document.siblings.previous')}
+                >
+                    <ChevronLeft size={16} />
+                </Link>
+            ) : (
+                <span className={`${arrow} ${disabled}`} aria-hidden="true">
+                    <ChevronLeft size={16} />
+                </span>
+            )}
+
+            <span className="whitespace-nowrap text-xs tabular-nums text-vtk-muted">
+                {t('document.siblings.position', { index: index + 1, total: documents.length })}
+            </span>
+
+            {next ? (
+                <Link
+                    href={`/document/${next.id}`}
+                    className={arrow}
+                    title={next.name ?? t('document.siblings.next')}
+                    aria-label={t('document.siblings.next')}
+                >
+                    <ChevronRight size={16} />
+                </Link>
+            ) : (
+                <span className={`${arrow} ${disabled}`} aria-hidden="true">
+                    <ChevronRight size={16} />
+                </span>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/components/documentcategorypage/DocumentListItem.tsx
+++ b/frontend/src/components/documentcategorypage/DocumentListItem.tsx
@@ -4,7 +4,8 @@ import DownloadButton from '@/components/ui/DownloadButton';
 import FavoriteButton from '@/components/ui/FavoriteButton';
 import VoteButton from '@/components/ui/buttons/VoteButton';
 import type { Document } from '@/types/entities';
-import { Tag as TagIcon } from 'lucide-react';
+import { inlineUrl, previewKindFor } from '@/utils/previewableFile';
+import { ExternalLink, Tag as TagIcon } from 'lucide-react';
 import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
 
@@ -24,6 +25,12 @@ const DocumentListItem: React.FC<DocumentListItemProps> = ({ document, isSelecte
     // `author` is only ever filled in by the Seafile import, but the API does accept it on
     // create, so anonymity wins the tie rather than trusting that it stays that way.
     const showAuthor = Boolean(document.author) && !document.anonymous;
+
+    // Collection responses carry no mimetype - resolving one means touching the file - but the
+    // content URL ends in the stored filename, which is what decides previewability anyway.
+    const inlineHref = document.contentUrl && previewKindFor(document.contentUrl)
+        ? inlineUrl(document.contentUrl)
+        : null;
 
     return (
         // Wraps on narrow screens: the title row keeps the checkbox, and the
@@ -98,6 +105,20 @@ const DocumentListItem: React.FC<DocumentListItemProps> = ({ document, isSelecte
             <div className="ml-auto flex shrink-0 items-center gap-1.5">
                 <VoteButton type="document" objectId={document.id} size="small" />
                 <FavoriteButton itemId={document.id} itemType="document" size={16} />
+                {/* Opening a scan to check whether it is the right one should not mean putting a
+                    file on disk first, so the browser's own viewer sits next to the download. */}
+                {inlineHref && (
+                    <a
+                        href={inlineHref}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="vtk-icon-button h-8 w-8"
+                        title={t('document.open-in-browser')}
+                        aria-label={t('document.open-in-browser')}
+                    >
+                        <ExternalLink size={15} />
+                    </a>
+                )}
                 <DownloadButton documents={[document]} size={15} className="h-8 w-8" />
             </div>
         </div>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useCurriculumLocation } from '@/components/curriculum/CurriculumLocationContext';
+import CurriculumTree from '@/components/curriculum/CurriculumTree';
 import ItemList from '@/components/layout/ItemList';
 import CreateDocumentButton from '@/components/ui/CreateDocumentButton';
 import { useUser } from "@/components/UserContext";
@@ -30,11 +32,13 @@ const mapDocumentsToItems = (documents: Document[]) => {
 };
 
 /**
- * Favourites rail. Sticks under the navy header instead of owning a scroll
- * pane, so the page still scrolls as one document.
+ * The left rail: the curriculum folder tree for wherever the reader is, with their
+ * favourites underneath. Sticks under the navy header instead of owning a scroll pane, so
+ * the page still scrolls as one document.
  */
 const NavigationSidebar = () => {
   const { user } = useUser();
+  const { course } = useCurriculumLocation();
   const { t, i18n } = useTranslation();
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [expandedSections, setExpandedSections] = useState({
@@ -42,7 +46,9 @@ const NavigationSidebar = () => {
     documents: false
   });
 
-  if (!user) {
+  // Favourites need a reader; the folder tree only needs a page that sits somewhere in the
+  // curriculum. With neither there is nothing to put in the rail.
+  if (!user && !course) {
     return null;
   }
 
@@ -59,7 +65,7 @@ const NavigationSidebar = () => {
   return (
     <aside className="sticky top-[72px] hidden shrink-0 self-start md:block">
       <div
-        className={`relative flex h-[calc(100vh-72px)] flex-col border-r border-vtk-line bg-vtk-paper transition-[width] duration-300 ${isCollapsed ? 'w-16' : 'w-64'
+        className={`relative flex h-[calc(100vh-72px)] flex-col border-r border-vtk-line bg-vtk-paper transition-[width] duration-300 ${isCollapsed ? 'w-16' : 'w-72'
           }`}
       >
         {/* Collapse toggle */}
@@ -83,75 +89,89 @@ const NavigationSidebar = () => {
             {!isCollapsed && <span>{t('sidebar.home')}</span>}
           </Link>
 
-          <div className="my-1 border-t border-vtk-line" />
-
-          {/* Favourite courses */}
-          <button
-            type="button"
-            className={sectionButton}
-            onClick={() => {
-              toggleSection('courses');
-              setIsCollapsed(false);
-            }}
-            aria-expanded={expandedSections.courses}
-            aria-label={t('sidebar.my_courses')}
-          >
-            <span className="flex items-center gap-2.5">
-              <FolderClosed size={18} className="shrink-0" />
-              {!isCollapsed && <span>{t('sidebar.my_courses')}</span>}
-            </span>
-            {!isCollapsed && (
-              <ChevronDown
-                size={15}
-                className={`shrink-0 text-vtk-muted transition-transform duration-200 ${expandedSections.courses ? 'rotate-0' : '-rotate-90'
-                  }`}
-              />
-            )}
-          </button>
-          {!isCollapsed && expandedSections.courses && (
-            <ItemList
-              items={mapCoursesToItems(user.favoriteCourses ?? [], i18n.language)}
-              emptyMessage={t('account.favorite.no_courses')}
-            />
+          {/* Where the reader is in the curriculum. Only on pages that sit somewhere. */}
+          {!isCollapsed && course && (
+            <>
+              <div className="my-1 border-t border-vtk-line" />
+              <CurriculumTree />
+            </>
           )}
 
-          <div className="my-1 border-t border-vtk-line" />
+          {user && (
+            <>
+              <div className="my-1 border-t border-vtk-line" />
 
-          {/* Favourite documents */}
-          <button
-            type="button"
-            className={sectionButton}
-            onClick={() => {
-              toggleSection('documents');
-              setIsCollapsed(false);
-            }}
-            aria-expanded={expandedSections.documents}
-            aria-label={t('sidebar.my_favorite_documents')}
-          >
-            <span className="flex items-center gap-2.5">
-              <File size={18} className="shrink-0" />
-              {!isCollapsed && <span>{t('sidebar.my_favorite_documents')}</span>}
-            </span>
-            {!isCollapsed && (
-              <ChevronDown
-                size={15}
-                className={`shrink-0 text-vtk-muted transition-transform duration-200 ${expandedSections.documents ? 'rotate-0' : '-rotate-90'
-                  }`}
-              />
-            )}
-          </button>
-          {!isCollapsed && expandedSections.documents && (
-            <ItemList
-              items={mapDocumentsToItems(user.favoriteDocuments ?? [])}
-              emptyMessage={t('account.favorite.no_documents')}
-            />
+              {/* Favourite courses */}
+              <button
+                type="button"
+                className={sectionButton}
+                onClick={() => {
+                  toggleSection('courses');
+                  setIsCollapsed(false);
+                }}
+                aria-expanded={expandedSections.courses}
+                aria-label={t('sidebar.my_courses')}
+              >
+                <span className="flex items-center gap-2.5">
+                  <FolderClosed size={18} className="shrink-0" />
+                  {!isCollapsed && <span>{t('sidebar.my_courses')}</span>}
+                </span>
+                {!isCollapsed && (
+                  <ChevronDown
+                    size={15}
+                    className={`shrink-0 text-vtk-muted transition-transform duration-200 ${expandedSections.courses ? 'rotate-0' : '-rotate-90'
+                      }`}
+                  />
+                )}
+              </button>
+              {!isCollapsed && expandedSections.courses && (
+                <ItemList
+                  items={mapCoursesToItems(user.favoriteCourses ?? [], i18n.language)}
+                  emptyMessage={t('account.favorite.no_courses')}
+                />
+              )}
+
+              <div className="my-1 border-t border-vtk-line" />
+
+              {/* Favourite documents */}
+              <button
+                type="button"
+                className={sectionButton}
+                onClick={() => {
+                  toggleSection('documents');
+                  setIsCollapsed(false);
+                }}
+                aria-expanded={expandedSections.documents}
+                aria-label={t('sidebar.my_favorite_documents')}
+              >
+                <span className="flex items-center gap-2.5">
+                  <File size={18} className="shrink-0" />
+                  {!isCollapsed && <span>{t('sidebar.my_favorite_documents')}</span>}
+                </span>
+                {!isCollapsed && (
+                  <ChevronDown
+                    size={15}
+                    className={`shrink-0 text-vtk-muted transition-transform duration-200 ${expandedSections.documents ? 'rotate-0' : '-rotate-90'
+                      }`}
+                  />
+                )}
+              </button>
+              {!isCollapsed && expandedSections.documents && (
+                <ItemList
+                  items={mapDocumentsToItems(user.favoriteDocuments ?? [])}
+                  emptyMessage={t('account.favorite.no_documents')}
+                />
+              )}
+            </>
           )}
         </div>
 
         {/* Create document */}
-        <div className="shrink-0 border-t border-vtk-line p-3">
-          <CreateDocumentButton className="w-full" showText={!isCollapsed} size={17} />
-        </div>
+        {user && (
+          <div className="shrink-0 border-t border-vtk-line p-3">
+            <CreateDocumentButton className="w-full" showText={!isCollapsed} size={17} />
+          </div>
+        )}
       </div>
     </aside>
   );

--- a/frontend/src/components/ui/ComboboxController.tsx
+++ b/frontend/src/components/ui/ComboboxController.tsx
@@ -51,7 +51,15 @@ const ComboboxController: React.FC<ComboboxControllerProps> = ({
 
     return (
         <div>
-            <Combobox value={selectedOption} onChange={(option: Option | null) => onChange(option?.id)} disabled={disabled}>
+            <Combobox
+                value={selectedOption}
+                onChange={(option: Option | null) => onChange(option?.id)}
+                // Without this the typed query outlives the dropdown: reopening the field to
+                // change an answer showed the list still filtered by whatever was typed the
+                // previous time, which read as "the other options are gone".
+                onClose={() => setQuery('')}
+                disabled={disabled}
+            >
                 {({ open }) => (
                     <div className="relative">
                         <Combobox.Input

--- a/frontend/src/components/ui/DynamicBreadcrumb.tsx
+++ b/frontend/src/components/ui/DynamicBreadcrumb.tsx
@@ -9,6 +9,7 @@ import {
     BreadcrumbPage,
     BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+import { useCurriculumLocation } from '@/components/curriculum/CurriculumLocationContext';
 import type { Course, Document, DocumentCategory } from "@/types/entities";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
@@ -22,6 +23,10 @@ interface DynamicBreadcrumbProps {
 
 export default function DynamicBreadcrumb({ course, category, document }: DynamicBreadcrumbProps) {
     const { t, i18n } = useTranslation();
+    // The programme and modules the course hangs under, resolved once per page in the layout.
+    // "Home > Courses > Course" told a reader nothing about which of three programmes they
+    // were in, or which semester the course sits in - the parts they navigated through.
+    const { activePath } = useCurriculumLocation();
 
     const breadcrumbItems = [];
 
@@ -38,6 +43,25 @@ export default function DynamicBreadcrumb({ course, category, document }: Dynami
         href: '/courses',
         isCurrentPage: !course && !category && !document
     });
+
+    // The curriculum branch: programme, then the chain of modules down to the course. Both
+    // link back into the navigator opened on that node, which is where a reader who wants
+    // "the other courses in this semester" is heading.
+    if (course && activePath) {
+        breadcrumbItems.push({
+            label: activePath.program.name ?? '',
+            href: `/courses?program=${activePath.program.id}`,
+            isCurrentPage: false
+        });
+
+        activePath.modules.forEach((node) => {
+            breadcrumbItems.push({
+                label: node.name ?? '',
+                href: `/courses?module=${node.id}`,
+                isCurrentPage: false
+            });
+        });
+    }
 
     // Add Course if available
     if (course) {
@@ -73,10 +97,13 @@ export default function DynamicBreadcrumb({ course, category, document }: Dynami
                     <Fragment key={index}>
                         <BreadcrumbItem>
                             {item.isCurrentPage ? (
-                                <BreadcrumbPage>{item.label}</BreadcrumbPage>
+                                <BreadcrumbPage className="max-w-[22rem] truncate">{item.label}</BreadcrumbPage>
                             ) : (
                                 <BreadcrumbLink asChild>
-                                    <Link href={item.href}>{item.label}</Link>
+                                    {/* A full branch can name a programme, two modules and a course.
+                                        Each part truncates rather than the row scrolling, and the list
+                                        wraps, so a long trail costs a second line and never the layout. */}
+                                    <Link href={item.href} className="block max-w-[16rem] truncate">{item.label}</Link>
                                 </BreadcrumbLink>
                             )}
                         </BreadcrumbItem>

--- a/frontend/src/components/ui/SemesterIndicator.tsx
+++ b/frontend/src/components/ui/SemesterIndicator.tsx
@@ -46,10 +46,8 @@ const SemesterIndicator: React.FC<SemesterIndicatorProps> = ({
             strokeLinecap="round"
             strokeLinejoin="round"
         >
-            <g transform={first ? undefined : "translate(24, 0) scale(-1, 1)"}>
-                <path d="M12 2a10 10 0 0 0 0 20" />
-                <path d="M12 2v20" />
-            </g>
+            <path d={first ? "M12 2a10 10 0 0 0 0 20" : "M12 2a10 10 0 0 1 0 20"} />
+            <path d="M12 2v20" />
         </svg>
     );
 };

--- a/frontend/src/components/upload/UploadForm.tsx
+++ b/frontend/src/components/upload/UploadForm.tsx
@@ -8,7 +8,6 @@ import { useFormFields } from '@/hooks/useFormFields';
 import { useYearOptions } from '@/hooks/useYearOptions';
 import { Course, DocumentCategory } from '@/types/entities';
 import { UploadFormData } from '@/types/upload';
-import { VISIBLE_YEARS } from "@/utils/constants/upload";
 import { getSuggestedNameFromFilename } from '@/utils/documentNameSuggestion';
 import { documentSchema } from '@/utils/validation/documentSchema';
 import { localizedCourseName } from '@/utils/courseName';
@@ -58,11 +57,16 @@ export default function UploadForm({
     const { courses, categories, isLoading: isLoadingFields, error } = useFormFields();
     const yearOptions = useYearOptions();
 
+    // Alphabetical: the API returns courses in insertion order, which is the order they were
+    // imported in and means nothing to whoever is scrolling the list looking for their course.
+    // localeCompare so accented titles sort where a reader expects them, not after Z.
     const courseOptions = useMemo(() => {
-        return courses.map(course => ({
-            id: course.id,
-            name: localizedCourseName(course, i18n.language) || course.name || course.code || `${t('upload.form.course.label')} #${course.id}`
-        }));
+        return courses
+            .map(course => ({
+                id: course.id,
+                name: localizedCourseName(course, i18n.language) || course.name || course.code || `${t('upload.form.course.label')} #${course.id}`
+            }))
+            .sort((a, b) => a.name.localeCompare(b.name, i18n.language));
     }, [courses, i18n.language, t]);
 
     const categoryOptions = useMemo(() => {
@@ -154,6 +158,9 @@ export default function UploadForm({
                 </div>
 
                 <div className="md:col-span-2">
+                    {/* Every academic year the list offers is selectable: capping the dropdown at
+                        the five most recent hid the rest behind a search nobody knew to run, so
+                        an exam from 2015 could not be filed under the year it was taken. */}
                     <FormField
                         label={t('upload.form.year.label')}
                         type="combobox"
@@ -162,7 +169,6 @@ export default function UploadForm({
                         name="year"
                         control={control}
                         disabled={isLoading}
-                        visibleOptions={VISIBLE_YEARS}
                     />
                 </div>
 

--- a/frontend/src/hooks/useCoursePaths.ts
+++ b/frontend/src/hooks/useCoursePaths.ts
@@ -1,0 +1,42 @@
+import { useApi } from '@/hooks/useApi';
+import type { CurriculumPath } from '@/types/entities';
+import { convertToCurriculumPaths } from '@/utils/convertToEntity';
+import { useEffect, useState } from 'react';
+
+/**
+ * Every place a course sits in the curriculum. Empty while loading and for a course no
+ * programme reaches — callers render nothing rather than an empty frame in both cases.
+ */
+export function useCoursePaths(courseId?: number) {
+    const { request } = useApi<unknown>();
+    const [paths, setPaths] = useState<CurriculumPath[]>([]);
+    const [loading, setLoading] = useState(courseId !== undefined);
+
+    useEffect(() => {
+        if (courseId === undefined) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            setPaths([]);
+            setLoading(false);
+            return;
+        }
+
+        let cancelled = false;
+        setLoading(true);
+
+        const fetchPaths = async () => {
+            const result = await request('GET', `/api/courses/${courseId}/paths`);
+            if (cancelled) return;
+
+            setPaths(result ? convertToCurriculumPaths(result) : []);
+            setLoading(false);
+        };
+
+        void fetchPaths();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [courseId, request]);
+
+    return { paths, loading };
+}

--- a/frontend/src/hooks/useSiblingDocuments.ts
+++ b/frontend/src/hooks/useSiblingDocuments.ts
@@ -1,0 +1,58 @@
+import { HydraCollection, useApi } from '@/hooks/useApi';
+import type { Document } from '@/types/entities';
+import { convertToDocument } from '@/utils/convertToEntity';
+import { useEffect, useState } from 'react';
+
+/**
+ * A category never holds this many documents in practice, but a course with a decade of
+ * scanned exercise sessions can come close. Past the cap the neighbours are simply not
+ * offered rather than paged through - the full list stays one click away either way.
+ */
+const MAX_SIBLINGS = 200;
+
+/**
+ * The documents sitting in the same course and category as the one being read, in the order
+ * the category page lists them: newest academic year first, name as the tiebreaker.
+ *
+ * Reading one of six exercise sessions used to mean going back to the folder for every next
+ * file; with the neighbours in hand the reader can step straight from one to the next.
+ */
+export function useSiblingDocuments(courseId?: number, categoryId?: number) {
+    const { request } = useApi<HydraCollection<unknown>>();
+    const [documents, setDocuments] = useState<Document[]>([]);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        if (courseId === undefined || categoryId === undefined) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            setDocuments([]);
+            return;
+        }
+
+        let cancelled = false;
+        setLoading(true);
+
+        const fetchSiblings = async () => {
+            const url = `/api/documents?page=1&itemsPerPage=${MAX_SIBLINGS}`
+                + '&includeFileMetadata=false'
+                + `&course=${encodeURIComponent(`/api/courses/${courseId}`)}`
+                + `&category=${encodeURIComponent(`/api/document_categories/${categoryId}`)}`
+                + '&order[year]=desc&order[name]=asc';
+
+            const response = await request('GET', url);
+            if (cancelled) return;
+
+            const members = response?.['hydra:member'];
+            setDocuments(Array.isArray(members) ? members.map(convertToDocument) : []);
+            setLoading(false);
+        };
+
+        void fetchSiblings();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [courseId, categoryId, request]);
+
+    return { documents, loading };
+}

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -2,6 +2,7 @@ import type { Page } from "@/types/entities";
 import { convertToPage } from "@/utils/convertToEntity";
 import { COOKIE_NAMES } from "@/utils/cookieNames";
 import { decodeJWT, isJWTExpired } from "@/utils/jwt";
+import { refreshTokenExpiry, SESSION_COOKIE_SAME_SITE } from "@/utils/sessionCookies";
 import { captureException } from "@sentry/nextjs";
 import { i18nRouter } from 'next-i18n-router';
 import { NextRequest, NextResponse } from "next/server";
@@ -76,7 +77,18 @@ const checkAuthentication = (request: NextRequest): boolean => {
  * Attempt to refresh tokens in middleware
  * This is a simplified version that doesn't store cookies (Edge Runtime limitation)
  */
-const tryRefreshToken = async (request: NextRequest): Promise<string | null> => {
+/**
+ * What a refresh hands back. The refresh token matters as much as the JWT: refresh tokens are
+ * single-use, so the backend replaces the one that was spent, and a client that keeps the old
+ * one is holding a token that has already been invalidated.
+ */
+interface RefreshedSession {
+    jwt: string;
+    refreshToken?: string;
+    refreshTokenExpiration?: number;
+}
+
+const tryRefreshToken = async (request: NextRequest): Promise<RefreshedSession | null> => {
     const refreshToken = request.cookies.get(COOKIE_NAMES.REFRESH_TOKEN)?.value;
 
     if (!refreshToken) {
@@ -96,7 +108,11 @@ const tryRefreshToken = async (request: NextRequest): Promise<string | null> => 
 
         if (response.ok) {
             const data = await response.json();
-            return data.token;
+            return {
+                jwt: data.token,
+                refreshToken: data.refresh_token,
+                refreshTokenExpiration: data.refresh_token_expiration,
+            };
         }
 
         return null;
@@ -139,26 +155,42 @@ export default async function proxy(request: NextRequest) {
         // 1. We have a refresh token AND
         // 2. Either no JWT OR an expired JWT
         if (refreshToken && (!jwt || isJWTExpired(jwt))) {
-            const newJwt = await tryRefreshToken(request);
+            const refreshed = await tryRefreshToken(request);
 
-            if (newJwt) {
+            if (refreshed) {
                 // Create response with new JWT cookie
                 const response = i18nRouter(request, i18nConfig);
 
                 // Calculate new JWT expiration
-                const jwtPayload = decodeJWT(newJwt);
+                const jwtPayload = decodeJWT(refreshed.jwt);
                 const jwtExpiration = jwtPayload?.exp ? new Date(jwtPayload.exp * 1000) : new Date(Date.now() + 15 * 60 * 1000); // 15 min fallback
 
                 // Set new JWT cookie
                 response.cookies.set({
                     name: COOKIE_NAMES.JWT,
-                    value: newJwt,
+                    value: refreshed.jwt,
                     path: '/',
                     httpOnly: true,
                     secure: process.env.NODE_ENV === 'production',
-                    sameSite: 'strict',
+                    sameSite: SESSION_COOKIE_SAME_SITE,
                     expires: jwtExpiration,
                 });
+
+                // And the replacement refresh token. Spending one invalidates it server-side,
+                // so keeping the old one meant the session survived exactly one refresh: the
+                // hour after that, the next refresh was rejected and the reader was thrown
+                // back to the login page with a month of session life left unused.
+                if (refreshed.refreshToken) {
+                    response.cookies.set({
+                        name: COOKIE_NAMES.REFRESH_TOKEN,
+                        value: refreshed.refreshToken,
+                        path: '/',
+                        httpOnly: true,
+                        secure: process.env.NODE_ENV === 'production',
+                        sameSite: SESSION_COOKIE_SAME_SITE,
+                        expires: refreshTokenExpiry(refreshed.refreshTokenExpiration),
+                    });
+                }
 
                 // Mark as authenticated since we got a new token
                 isAuthenticated = true;

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -242,11 +242,16 @@
         "related": {
             "predecessors": "Previously taught as",
             "successors": "Now taught as",
-            "equivalents": "Equivalent to"
+            "equivalents": "Equivalent to",
+            "documents_one": "{{count}} document",
+            "documents_other": "{{count}} documents"
         },
         "show-empty-categories": "Show empty folders ({{count}})",
         "hide-empty-categories": "Hide empty folders",
-        "no-documents-yet": "This course has no documents yet."
+        "no-documents-yet": "This course has no documents yet.",
+        "placement": {
+            "label": "This course sits in"
+        }
     },
     "download": {
         "download": "Download",
@@ -364,7 +369,13 @@
         },
         "under-review-warning": "This document is currently under review, so it is only visible to you.",
         "author": "Author",
-        "uploaded-by": "Uploaded by"
+        "uploaded-by": "Uploaded by",
+        "open-in-browser": "Open in browser",
+        "siblings": {
+            "previous": "Previous document",
+            "next": "Next document",
+            "position": "{{index}} of {{total}}"
+        }
     },
     "pagination": {
         "previous": "Previous",
@@ -439,5 +450,8 @@
     },
     "metadata": {
         "courses": "Browse all available courses on Burgieclan."
+    },
+    "curriculum-tree": {
+        "label": "Folders"
     }
 }

--- a/frontend/src/translations/nl.json
+++ b/frontend/src/translations/nl.json
@@ -242,11 +242,16 @@
         "related": {
             "predecessors": "Vroeger gegeven als",
             "successors": "Nu gegeven als",
-            "equivalents": "Gelijkwaardig aan"
+            "equivalents": "Gelijkwaardig aan",
+            "documents_one": "{{count}} document",
+            "documents_other": "{{count}} documenten"
         },
         "show-empty-categories": "Toon lege mappen ({{count}})",
         "hide-empty-categories": "Verberg lege mappen",
-        "no-documents-yet": "Er staan nog geen documenten bij dit vak."
+        "no-documents-yet": "Er staan nog geen documenten bij dit vak.",
+        "placement": {
+            "label": "Dit vak zit in"
+        }
     },
     "download": {
         "download": "Download",
@@ -364,7 +369,13 @@
         },
         "under-review-warning": "Dit document is momenteel in behandeling, dus het is alleen zichtbaar voor jou.",
         "author": "Auteur",
-        "uploaded-by": "Geüpload door"
+        "uploaded-by": "Geüpload door",
+        "open-in-browser": "Openen in browser",
+        "siblings": {
+            "previous": "Vorig document",
+            "next": "Volgend document",
+            "position": "{{index}} van {{total}}"
+        }
     },
     "pagination": {
         "previous": "Vorige",
@@ -439,5 +450,8 @@
     },
     "metadata": {
         "courses": "Blader door alle vakken op Burgieclan."
+    },
+    "curriculum-tree": {
+        "label": "Mappen"
     }
 }

--- a/frontend/src/types/entities.ts
+++ b/frontend/src/types/entities.ts
@@ -28,6 +28,11 @@ export interface Course extends BaseEntity {
     /** Courses teaching the same subject under another code, e.g. a sister-faculty variant. */
     identicalCourses?: Course[];
     documentCounts?: Record<number, number>;
+    /**
+     * Published documents on this course as a single total. Only sent for the related courses
+     * on a course detail response, so it is undefined on a course fetched on its own.
+     */
+    documentCount?: number;
 }
 
 
@@ -53,6 +58,16 @@ export interface Program extends BaseEntity {
 export interface ModulePath {
     programId: number | null;
     moduleIds: number[];
+}
+
+/**
+ * One place a course sits in the curriculum: the program, and the chain of modules from that
+ * program's top level down to the module that teaches it. A course shared between programmes
+ * has one of these per programme.
+ */
+export interface CurriculumPath {
+    program: Program;
+    modules: Module[];
 }
 
 export interface AbstractComment extends NodeEntity {

--- a/frontend/src/utils/constants/upload.ts
+++ b/frontend/src/utils/constants/upload.ts
@@ -158,5 +158,4 @@ export const isAllowedFile = (file: File): boolean => {
 export const FILE_SIZE_MB = 200;
 export const FILE_SIZE_LIMIT = FILE_SIZE_MB * 1024 * 1024;
 
-export const VISIBLE_YEARS = 5;
 export const MAX_YEARS_HISTORY = 20;

--- a/frontend/src/utils/convertToEntity.ts
+++ b/frontend/src/utils/convertToEntity.ts
@@ -9,6 +9,7 @@ import {
     type DocumentComment,
     type DocumentView,
     type FaqItem,
+    type CurriculumPath,
     type Module,
     type ModulePath,
     type Page,
@@ -67,6 +68,21 @@ export function convertToModulePath(path: unknown): ModulePath {
     };
 }
 
+/**
+ * The curriculum placements returned by `/api/courses/{id}/paths`. Programs and modules come
+ * back as IRI + name, which is exactly the shape convertToProgram/convertToModule already read.
+ */
+export function convertToCurriculumPaths(response: unknown): CurriculumPath[] {
+    const data = toRecord(response, 'CurriculumPaths');
+    return (asArray(data.paths) ?? []).map((path) => {
+        const entry = toRecord(path, 'CurriculumPath');
+        return {
+            program: convertToProgram(entry.program),
+            modules: (asArray(entry.modules) ?? []).map(convertToModule)
+        };
+    });
+}
+
 export function convertToCourse(course: unknown): Course {
     if (typeof course === 'string' || typeof course === 'number') {
         return { id: parseId(course) };
@@ -88,7 +104,8 @@ export function convertToCourse(course: unknown): Course {
         courseComments: asArray(data.courseComments)?.map(convertToCourseComment),
         documentCounts: (data.documentCounts && typeof data.documentCounts === 'object' && !Array.isArray(data.documentCounts))
             ? (data.documentCounts as Record<number, number>)
-            : (Array.isArray(data.documentCounts) && data.documentCounts.length === 0 ? {} : undefined)
+            : (Array.isArray(data.documentCounts) && data.documentCounts.length === 0 ? {} : undefined),
+        documentCount: typeof data.documentCount === 'number' ? data.documentCount : undefined
     };
 }
 

--- a/frontend/src/utils/curriculumBranch.ts
+++ b/frontend/src/utils/curriculumBranch.ts
@@ -1,0 +1,56 @@
+import type { CurriculumPath } from '@/types/entities';
+
+const STORAGE_KEY = 'burgieclan:curriculum-branch';
+
+/**
+ * The branch the reader walked to get to a course, as the id of the module they came from.
+ *
+ * A course shared between programmes sits in several places, and nothing in the URL of a
+ * course, category or document page says which one the reader came through. Without a memory
+ * the breadcrumb and the folder tree would pick a different branch on every step of
+ * course -> category -> document, which is worse than picking one and staying with it.
+ * Session-scoped on purpose: this is navigation state, not a preference, and it should not
+ * outlive the tab.
+ */
+export function rememberBranch(courseId: number, leafModuleId: number): void {
+    try {
+        sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ courseId, leafModuleId }));
+    } catch {
+        // Private mode and storage-blocking settings throw here. The fallback - the course's
+        // first placement - is perfectly usable, so there is nothing to recover.
+    }
+}
+
+/** The remembered module for this course, or null when there is none. */
+export function recallBranch(courseId: number): number | null {
+    try {
+        const raw = sessionStorage.getItem(STORAGE_KEY);
+        if (!raw) return null;
+
+        const parsed: unknown = JSON.parse(raw);
+        if (typeof parsed !== 'object' || parsed === null) return null;
+
+        const { courseId: storedCourse, leafModuleId } = parsed as Record<string, unknown>;
+        if (storedCourse !== courseId || typeof leafModuleId !== 'number') return null;
+
+        return leafModuleId;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Which of a course's placements to show: the branch the reader walked earlier in this tab if
+ * one of them matches, otherwise simply the first.
+ */
+export function selectPath(paths: CurriculumPath[], courseId: number): CurriculumPath | null {
+    if (paths.length === 0) return null;
+
+    const remembered = recallBranch(courseId);
+    if (remembered !== null) {
+        const previous = paths.find((path) => path.modules.some((module) => module.id === remembered));
+        if (previous) return previous;
+    }
+
+    return paths[0];
+}

--- a/frontend/src/utils/previewableFile.ts
+++ b/frontend/src/utils/previewableFile.ts
@@ -1,0 +1,68 @@
+/**
+ * The file types Burgieclan renders in the browser instead of handing over as a download.
+ *
+ * Mirrors `backend/src/Constants/PreviewableFile.php`, which decides what `?inline=1` actually
+ * serves; the two lists have to be changed together. Extensions rather than the stored
+ * mimetype on purpose: VichUploader falls back to application/octet-stream when the entity has
+ * no mimeType field, so the filename is the more reliable signal - and it is the only one a
+ * collection response carries.
+ *
+ * Deliberately absent, as on the backend: HTML and SVG. Both can carry script and are served
+ * from the app's own origin, so drawing them inline would be stored XSS.
+ */
+export type PreviewKind = 'pdf' | 'image' | 'text';
+
+const KIND_BY_EXTENSION: Record<string, PreviewKind> = {
+    pdf: 'pdf',
+    png: 'image',
+    jpg: 'image',
+    jpeg: 'image',
+    gif: 'image',
+    webp: 'image',
+    txt: 'text',
+    md: 'text',
+    markdown: 'text',
+    csv: 'text',
+    m: 'text',
+    py: 'text',
+    r: 'text',
+    c: 'text',
+    cpp: 'text',
+    h: 'text',
+    java: 'text',
+};
+
+const MIME_KIND: [prefix: string, kind: PreviewKind][] = [
+    ['application/pdf', 'pdf'],
+    ['image/', 'image'],
+];
+
+/**
+ * How a file should be drawn, or null when it cannot be drawn at all.
+ *
+ * Takes anything that ends in the stored filename - the filename itself or the content URL,
+ * which is that filename behind a download route - plus the mimetype when the response
+ * carried one.
+ */
+export function previewKindFor(source?: string, mimetype?: string): PreviewKind | null {
+    if (mimetype) {
+        const match = MIME_KIND.find(([prefix]) => mimetype.startsWith(prefix));
+        // SVG is an image by MIME type but never previewable; fall through to the extension.
+        if (match && mimetype !== 'image/svg+xml') {
+            return match[1];
+        }
+    }
+
+    if (!source) return null;
+
+    // Strip a query string first: a content URL may already carry ?inline=1.
+    const path = source.split('?')[0];
+    const extension = path.slice(path.lastIndexOf('.') + 1).toLowerCase();
+
+    return KIND_BY_EXTENSION[extension] ?? null;
+}
+
+/** The URL that opens a document in the browser's own viewer rather than downloading it. */
+export function inlineUrl(contentUrl: string): string {
+    return `${contentUrl}?inline=1`;
+}

--- a/frontend/src/utils/sessionCookies.ts
+++ b/frontend/src/utils/sessionCookies.ts
@@ -1,0 +1,32 @@
+/**
+ * How long a session survives without anyone logging in again, and how its cookies are scoped.
+ *
+ * Shared by the proxy and the server actions because both write these cookies, and a mismatch
+ * between the two is invisible until a session quietly dies.
+ */
+
+/**
+ * `lax`, not `strict`.
+ *
+ * Under `strict` the browser withholds session cookies on any navigation that started somewhere
+ * else, so arriving from a link in Discord, Teams or a mail read as "not logged in" and bounced
+ * the reader to the login page - even with a perfectly valid month-old session sitting in the
+ * jar. `lax` still withholds them on cross-site POSTs, which is the case CSRF actually needs,
+ * and is the standard setting for a session cookie.
+ */
+export const SESSION_COOKIE_SAME_SITE = 'lax' as const;
+
+/** Matches the backend's gesdinet_jwt_refresh_token ttl; used when a response omits its own. */
+const REFRESH_TOKEN_FALLBACK_DAYS = 30;
+
+/**
+ * When the refresh-token cookie should expire, from the Unix timestamp the backend sends back.
+ *
+ * The cookie must not outlive the token it carries, and must not die before it either: an
+ * expiry shorter than the token's throws away session life the backend was still honouring.
+ */
+export function refreshTokenExpiry(expiration?: number): Date {
+    return typeof expiration === 'number'
+        ? new Date(expiration * 1000)
+        : new Date(Date.now() + REFRESH_TOKEN_FALLBACK_DAYS * 24 * 60 * 60 * 1000);
+}


### PR DESCRIPTION
Werkt de feedback van elf studenten weg. Waar studenten elkaar tegenspraken is de
onderliggende klacht opgezocht in plaats van één kant te kiezen.

## De grote lijn: oriëntatie

Vijf studenten zeiden onafhankelijk hetzelfde: je klikt je een weg door menu's en
dropdowns, en eenmaal ergens weet je niet meer waar "ergens" is. Twee noemden de
mappenboom van de oude Burgieclan als het enige dat het oude systeem beter deed.

Eén student vroeg daarom om *pagina's* in plaats van uitklapbare tabs; twee andere
vroegen juist om de uitklapbare boom te behouden. Dat lijkt tegenstrijdig, maar de
klacht eronder is dezelfde: *"als je teruggaat moet je weer heel je weg
terugzoeken."* Niet de tabs waren het probleem, wel dat ze hun staat verloren. Dus:

- **De boomstaat staat nu in de URL.** De browserknop "terug" brengt je terug in de
  boom zoals je hem achterliet, en je positie is een link die je kan doorsturen.
- **De mappenboom staat weer in de zijbalk** op elke vak-, categorie- en
  documentpagina: richting → modules → vakken → categorieën → documenten, opengeklapt
  tot waar je staat en met de buren op elk niveau.
- **Breadcrumbs dragen de richting en de modules**, zoals letterlijk gevraagd:
  `home > courses > master energie > semester > vak`, elk onderdeel een link terug
  naar de navigator op dat punt.
- **Een vak dat in meerdere richtingen zit toont ze allemaal** en laat je wisselen —
  de breadcrumb kan er maar één tegelijk tonen, en *"zit ik wel goed?"* was precies de
  vraag.
- **Vorige/volgende op een document**, in de volgorde van de categoriepagina, zodat
  oefenzitting 1 van 6 naar oefenzitting 2 leidt.

Backend: `GET /api/courses/{id}/paths` geeft elke plaats in het curriculum met namen
erbij, zodat een breadcrumb geen extra request per knoop nodig heeft.

## Losse punten

- **Openen in de browser-viewer nu ook vanuit de lijst** — daar maak je de keuze, niet
  op de documentpagina. (`document.open-in-browser` ontbrak trouwens in beide
  vertaalbestanden; de knop die er al stond toonde de ruwe sleutel als tooltip.)
- **Academiejaar bij uploaden** — de lijst was afgekapt op de vijf recentste, dus een
  examen van 2015 kon je niet indienen onder zijn jaar. En het zoekwoord bleef staan
  bij heropenen, waardoor de lijst leeg leek. Beide weg.
- **Vakken alfabetisch** in de upload-dropdown; ze stonden in importvolgorde.
- **"Vroeger gegeven als" toont nu hoeveel documenten daar staan.** Een student vond
  samenvattingen en oude examenvragen alleen bij toeval en noemde het oude vak
  *"verstopt"*.

## Sessie blijft nu bewaard

Los van de studentenfeedback, apart gemeld: je moest ongeveer dagelijks opnieuw
inloggen. De TTL stond al op 30 dagen — de sessie werd vroegtijdig vernietigd:

1. De proxy verniewde de JWT maar bewaarde enkel de JWT. Refresh tokens zijn
   single-use, dus de vervanger die de backend teruggaf ging verloren; een uur later
   werd de volgende refresh geweigerd en werden de cookies gewist. Nagegaan tegen de
   draaiende backend: een gebruikt token geeft 401.
2. `getActiveJWT` gaf op zodra de JWT-cookie weg was — die verloopt na een uur, dus
   bij een volgend bezoek werd het refresh token nooit geraadpleegd.
3. `SameSite=strict` betekende dat een link vanuit Discord of mail zónder cookies
   aankwam en naar de loginpagina stuurde, met een geldige sessie in de jar. Nu `lax`.

Elke refresh geeft een nieuw token van 30 dagen, dus het venster schuift mee.

## Niet in code opgelost

Drie punten horen in de admin of in de data, niet hier:

- **Kortrijk/KULAK** — vraagt een eigen richting/module in de admin plus het importeren
  van de gedeelde Drive-map. Data, geen code.
- **Beoordeling van thesisbegeleiders** — het bestaande systeem van comment-categorieën
  met sterrenscores per vak doet dit al; het vraagt één categorie in de admin, geen
  tweede systeem ernaast.
- **P&O2 toont inhoud van Beton1, en ontbrekende migratie van Wijsbegeerte** — fouten in
  de import/data. De "verstopt"-helft is wel aangepakt via de documentaantallen
  hierboven.

## Checks

`npm run lint`, `npm run build`, `npx tsc --noEmit`, `make phpstan`, `make phpcs` en
`make phpunit` (344 tests) draaien groen. Nieuwe backendtests dekken de paths-endpoint
(inclusief een vak in twee richtingen, een vak buiten elke richting, en 404) en de
documentaantallen op gerelateerde vakken.
