### PR TITLE
perf: make curriculum navigation feel instant

### DIFF
--- a/frontend/src/app/[locale]/loading.tsx
+++ b/frontend/src/app/[locale]/loading.tsx
@@ -1,5 +1,0 @@
-import LoadingPage from "@/components/loading/LoadingPage";
-
-export default function Loading() {
-    return <LoadingPage />
-}

--- a/frontend/src/components/account/AccountPage.tsx
+++ b/frontend/src/components/account/AccountPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { logOut } from "@/actions/auth";
-import Loading from "@/app/[locale]/loading";
+import Loading from "@/components/loading/LoadingPage";
 import { useUser } from "@/components/UserContext";
 import AnonymousSetting from "@/components/account/AnonymousSetting";
 import DocumentList from "@/components/account/DocumentList";

--- a/frontend/src/components/coursepage/CourseDocumentsContent.tsx
+++ b/frontend/src/components/coursepage/CourseDocumentsContent.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import Loading from '@/app/[locale]/loading';
+import Loading from '@/components/loading/LoadingPage';
 import { usePublishCurriculumLocation } from '@/components/curriculum/CurriculumLocationContext';
 import DocumentCategoryPage from '@/components/documentcategorypage/DocumentCategoryPage';
-import { useApi } from '@/hooks/useApi';
+import { readPreloadedApi, useApi } from '@/hooks/useApi';
 import type { Course, DocumentCategory } from '@/types/entities';
 import { convertToCourse, convertToDocumentCategory } from '@/utils/convertToEntity';
 import { useEffect, useState } from 'react';
@@ -16,43 +16,55 @@ interface CourseDocumentsContentProps {
 }
 
 export default function CourseDocumentsContent({ courseId, categoryId }: CourseDocumentsContentProps) {
-    const [course, setCourse] = useState<Course | null>(null);
-    const [category, setCategory] = useState<DocumentCategory | null>(null);
-    const { request } = useApi();
     const { i18n } = useTranslation();
     const currentLocale = i18n.language;
+    const courseEndpoint = `/api/courses/${courseId}?summary=true`;
+    const categoryEndpoint = `/api/document_categories/${categoryId}?lang=${currentLocale}`;
+    const [course, setCourse] = useState<Course | null>(() => {
+        const preloaded = readPreloadedApi(courseEndpoint);
+        return preloaded ? convertToCourse(preloaded) : null;
+    });
+    const [category, setCategory] = useState<DocumentCategory | null>(() => {
+        const preloaded = readPreloadedApi(categoryEndpoint);
+        return preloaded ? convertToDocumentCategory(preloaded) : null;
+    });
+    const { request } = useApi();
 
     useEffect(() => {
         async function getCourse() {
+            if (course?.id === courseId) return;
+
             // The category page only renders course identity data in its heading/breadcrumb.
             // Avoid mapping comments, related courses, modules, and document counts again.
-            const courseData = await request('GET', `/api/courses/${courseId}?summary=true`);
+            const courseData = await request('GET', courseEndpoint);
 
             if (!courseData) {
                 return null;
             }
 
-            const course = convertToCourse(courseData);
-            setCourse(course);
+            const convertedCourse = convertToCourse(courseData);
+            setCourse(convertedCourse);
         }
 
         getCourse();
-    }, [courseId, request]);
+    }, [course?.id, courseEndpoint, courseId, request]);
 
     useEffect(() => {
         async function getCategory() {
-            const categoryData = await request('GET', `/api/document_categories/${categoryId}?lang=${currentLocale}`);
+            if (category?.id === categoryId) return;
+
+            const categoryData = await request('GET', categoryEndpoint);
 
             if (!categoryData) {
                 return null;
             }
 
-            const category = convertToDocumentCategory(categoryData);
-            setCategory(category);
+            const convertedCategory = convertToDocumentCategory(categoryData);
+            setCategory(convertedCategory);
         }
 
         getCategory();
-    }, [categoryId, request, currentLocale]);
+    }, [category?.id, categoryEndpoint, categoryId, request]);
 
     // Feeds the folder tree and the breadcrumb in the layout, which cannot read this route.
     usePublishCurriculumLocation({ course: course ?? undefined, category: category ?? undefined });

--- a/frontend/src/components/coursepage/CoursePage.tsx
+++ b/frontend/src/components/coursepage/CoursePage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Loading from '@/app/[locale]/loading';
+import Loading from '@/components/loading/LoadingPage';
 import CoursePlacement from "@/components/curriculum/CoursePlacement";
 import { usePublishCurriculumLocation } from "@/components/curriculum/CurriculumLocationContext";
 import CommentCategories from "@/components/coursepage/comment/CommentCategories";
@@ -13,7 +13,7 @@ import PageHead from "@/components/ui/PageHead";
 import FavoriteButton from "@/components/ui/FavoriteButton";
 import SemesterIndicator from '@/components/ui/SemesterIndicator';
 import { useUser } from '@/components/UserContext';
-import { useApi } from "@/hooks/useApi";
+import { readPreloadedApi, useApi } from "@/hooks/useApi";
 import { Course, CourseComment } from "@/types/entities";
 import { convertToCourse } from "@/utils/convertToEntity";
 import { ChartPie, Link as LinkIcon } from "lucide-react";
@@ -25,14 +25,20 @@ import { localizedCourseName } from '@/utils/courseName';
 
 export default function CoursePage() {
     const { id: courseId } = useParams();
-    const [course, setCourse] = useState<Course | null>(null);
+    const endpoint = `/api/courses/${courseId}`;
+    const [course, setCourse] = useState<Course | null>(() => {
+        const preloaded = readPreloadedApi(endpoint);
+        return preloaded ? convertToCourse(preloaded) : null;
+    });
     const { loading: userLoading } = useUser();
     const { t, i18n } = useTranslation();
     const { request, loading, error } = useApi();
 
     useEffect(() => {
+        if (course?.id === Number(courseId)) return;
+
         async function getCourse() {
-            const courseData = await request('GET', `/api/courses/${courseId}`);
+            const courseData = await request('GET', endpoint);
 
             if (!courseData) {
                 return null;
@@ -46,7 +52,7 @@ export default function CoursePage() {
         if (!userLoading) {
             getCourse();
         }
-    }, [courseId, userLoading, request]);
+    }, [course?.id, courseId, endpoint, userLoading, request]);
 
     // Feeds the folder tree and the breadcrumb in the layout, which cannot read this route.
     usePublishCurriculumLocation({ course: course ?? undefined });

--- a/frontend/src/components/coursepage/DocumentCategory.tsx
+++ b/frontend/src/components/coursepage/DocumentCategory.tsx
@@ -1,16 +1,17 @@
 'use client'
 
 import { FileText } from "lucide-react";
-import Link from "next/link";
+import ApiPrefetchLink from '@/components/ui/ApiPrefetchLink';
 import { useTranslation } from "react-i18next";
 
 interface DocumentCategoryProps {
     title: string;
     href: string;
     count?: number;
+    apiEndpoints?: string[];
 }
 
-export default function DocumentCategory({ title, href, count = 0 }: DocumentCategoryProps) {
+export default function DocumentCategory({ title, href, count = 0, apiEndpoints }: DocumentCategoryProps) {
     const { t } = useTranslation();
 
     const countLabel = count === 0
@@ -20,7 +21,7 @@ export default function DocumentCategory({ title, href, count = 0 }: DocumentCat
             : t('course-page.document-count.other', { count });
 
     return (
-        <Link href={href} className="group block rounded-[18px] focus:outline-hidden focus-visible:ring-2 focus-visible:ring-vtk-navy focus-visible:ring-offset-2">
+        <ApiPrefetchLink href={href} apiEndpoints={apiEndpoints} className="group block rounded-[18px] focus:outline-hidden focus-visible:ring-2 focus-visible:ring-vtk-navy focus-visible:ring-offset-2">
             <div className="flex h-full flex-col justify-between gap-6 rounded-[18px] border border-vtk-line bg-vtk-surface p-5 transition-[transform,border-color] duration-200 group-hover:-translate-y-0.5 group-hover:border-vtk-line-2">
                 <div className="flex items-center justify-between gap-2.5">
                     <div className="flex items-center gap-2.5 min-w-0">
@@ -39,6 +40,6 @@ export default function DocumentCategory({ title, href, count = 0 }: DocumentCat
                     {t('course-page.view-documents')}
                 </span>
             </div>
-        </Link>
+        </ApiPrefetchLink>
     );
 }

--- a/frontend/src/components/coursepage/DocumentSections.tsx
+++ b/frontend/src/components/coursepage/DocumentSections.tsx
@@ -1,9 +1,9 @@
 'use client'
-import Loading from '@/app/[locale]/loading';
+import Loading from '@/components/loading/LoadingPage';
 import DocumentCategoryPage from "@/components/coursepage/DocumentCategory";
 import CreateDocumentButton from '@/components/ui/CreateDocumentButton';
 import DownloadButton from "@/components/ui/DownloadButton";
-import { HydraCollection, useApi } from "@/hooks/useApi";
+import { HydraCollection, readPreloadedApi, useApi } from "@/hooks/useApi";
 import type { DocumentCategory } from "@/types/entities";
 import { convertToDocumentCategory } from "@/utils/convertToEntity";
 import { useEffect, useState } from "react";
@@ -15,17 +15,22 @@ interface DocumentSectionsProps {
 }
 
 export default function DocumentSections({ courseId, documentCounts }: DocumentSectionsProps) {
-    const [documentCategories, setDocumentCategories] = useState<DocumentCategory[]>([]);
-    const [showEmpty, setShowEmpty] = useState(false);
     const { t, i18n } = useTranslation();
+    const categoriesEndpoint = `/api/document_categories?lang=${i18n.language}`;
+    const [documentCategories, setDocumentCategories] = useState<DocumentCategory[]>(() => {
+        const preloaded = readPreloadedApi(categoriesEndpoint) as HydraCollection<unknown> | undefined;
+        return preloaded?.['hydra:member'].map(convertToDocumentCategory) ?? [];
+    });
+    const [showEmpty, setShowEmpty] = useState(false);
     const { request, loading } = useApi<HydraCollection<unknown>>();
 
     const countFor = (category: DocumentCategory) => documentCounts?.[category.id] ?? 0;
 
     useEffect(() => {
+        if (documentCategories.length > 0) return;
+
         async function fetchDocumentCategories() {
-            const lang = i18n.language;
-            const result = await request('GET', `/api/document_categories?lang=${lang}`);
+            const result = await request('GET', categoriesEndpoint);
             if (!result) {
                 return null;
             }
@@ -33,7 +38,7 @@ export default function DocumentSections({ courseId, documentCounts }: DocumentS
         }
 
         fetchDocumentCategories();
-    }, [request, i18n.language]);
+    }, [categoriesEndpoint, documentCategories.length, request]);
 
     // The counts exclude documents still under review, so a category holding nothing but
     // pending uploads reads as empty here. That is why hiding is reversible rather than
@@ -80,6 +85,10 @@ export default function DocumentSections({ courseId, documentCounts }: DocumentS
                             key={category.id}
                             title={category.name ?? ''}
                             href={`/course/${courseId}/documents/category/${category.id}`}
+                            apiEndpoints={[
+                                `/api/courses/${courseId}?summary=true`,
+                                `/api/document_categories/${category.id}?lang=${i18n.language}`,
+                            ]}
                             count={countFor(category)}
                         />
                     ))}

--- a/frontend/src/components/coursepage/RelatedCourses.tsx
+++ b/frontend/src/components/coursepage/RelatedCourses.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import type { Course } from '@/types/entities';
+import ApiPrefetchLink from '@/components/ui/ApiPrefetchLink';
 import { localizedCourseName } from '@/utils/courseName';
 import { ArrowLeft, ArrowRight, Equal } from 'lucide-react';
-import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
 
 interface RelatedCoursesProps {
@@ -45,9 +45,10 @@ export default function RelatedCourses({ course }: RelatedCoursesProps) {
                         {t(`course-page.related.${key}`)}
                     </span>
                     {courses.map((related) => (
-                        <Link
+                        <ApiPrefetchLink
                             key={related.id}
                             href={`/course/${related.id}`}
+                            apiEndpoints={`/api/courses/${related.id}`}
                             // Tailwind utilities win over the vtk-* component layer, so the
                             // hover colours override vtk-badge-muted without a custom variant
                             // (component-layer classes get no hover: variant of their own).
@@ -71,7 +72,7 @@ export default function RelatedCourses({ course }: RelatedCoursesProps) {
                                     {t('course-page.related.documents', { count: related.documentCount })}
                                 </span>
                             )}
-                        </Link>
+                        </ApiPrefetchLink>
                     ))}
                 </div>
             ))}

--- a/frontend/src/components/coursepage/comment/CommentCategories.tsx
+++ b/frontend/src/components/coursepage/comment/CommentCategories.tsx
@@ -1,4 +1,4 @@
-import Loading from '@/app/[locale]/loading';
+import Loading from '@/components/loading/LoadingPage';
 import CourseCommentList from '@/components/coursepage/comment/CourseCommentList';
 import { HydraCollection, useApi } from '@/hooks/useApi';
 import { CommentCategory, CourseComment, CourseRatingSummary, SectionRating } from '@/types/entities';

--- a/frontend/src/components/courses/CourseRow.tsx
+++ b/frontend/src/components/courses/CourseRow.tsx
@@ -2,13 +2,13 @@ import ProfessorDiv from '@/components/coursepage/ProfessorDiv';
 import DownloadButton from '@/components/ui/DownloadButton';
 import FavoriteButton from '@/components/ui/FavoriteButton';
 import SemesterIndicator from "@/components/ui/SemesterIndicator";
+import ApiPrefetchLink from '@/components/ui/ApiPrefetchLink';
 import { useProgramLanguage } from '@/components/courses/ProgramLanguageContext';
 import { useApi } from "@/hooks/useApi";
 import type { Course } from '@/types/entities';
 import { convertToCourse } from "@/utils/convertToEntity";
 import { rememberBranch } from '@/utils/curriculumBranch';
 import { captureException } from '@sentry/nextjs';
-import Link from "next/link";
 import { memo, useEffect, useState } from 'react';
 import Skeleton from 'react-loading-skeleton';
 import { useTranslation } from 'react-i18next';
@@ -135,8 +135,9 @@ export const CourseRow = memo(({
                         {content.name}
                     </div>
                 ) : (
-                    <Link
+                    <ApiPrefetchLink
                         href={`/course/${course.id}`}
+                        apiEndpoints={`/api/courses/${course.id}`}
                         // The branch the reader walked, so the course page's breadcrumb and
                         // folder tree name the programme they actually came from rather than
                         // whichever one the course happens to be listed under first.
@@ -144,7 +145,7 @@ export const CourseRow = memo(({
                         className="hover:text-vtk-navy hover:underline text-sm text-vtk-body rounded-xs focus:outline-hidden focus-visible:ring-2 focus-visible:ring-vtk-navy focus-visible:ring-offset-1"
                     >
                         {content.name}
-                    </Link>
+                    </ApiPrefetchLink>
                 )}
             </div>
             <div role="cell" className="col-span-1 flex items-center text-sm font-mono text-vtk-body">{content.code}</div>
@@ -163,4 +164,3 @@ export const CourseRow = memo(({
 });
 
 CourseRow.displayName = "CourseRow";
-

--- a/frontend/src/components/courses/CurriculumNavigator.tsx
+++ b/frontend/src/components/courses/CurriculumNavigator.tsx
@@ -1,20 +1,20 @@
 'use client'
 
-import Loading from '@/app/[locale]/loading';
+import Loading from '@/components/loading/LoadingPage';
 import CurriculumSearchBar, { SearchFilters } from '@/components/courses/CurriculumSearchBar';
 import CurriculumSearchResults, { CourseHit } from '@/components/curriculum/CurriculumSearchResults';
 import { curriculumHref } from '@/components/curriculum/curriculumLinks';
 import DownloadButton from '@/components/ui/DownloadButton';
+import ApiPrefetchLink from '@/components/ui/ApiPrefetchLink';
 import DynamicBreadcrumb from '@/components/ui/DynamicBreadcrumb';
 import FavoriteButton from '@/components/ui/FavoriteButton';
 import PageHead from '@/components/ui/PageHead';
 import { useUser } from "@/components/UserContext";
-import { HydraCollection, useApi } from '@/hooks/useApi';
+import { HydraCollection, readPreloadedApi, useApi } from '@/hooks/useApi';
 import type { Course, Module, Program } from '@/types/entities';
 import { convertToProgram } from "@/utils/convertToEntity";
 import { courseMatchesFilters, initializeFuseInstances } from '@/utils/curriculumSearchUtils';
 import { ChevronRight, GraduationCap } from 'lucide-react';
-import Link from 'next/link';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -43,7 +43,11 @@ function flatten(programs: Program[]): CourseHit[] {
  * and opening one programme no longer pushes the other nine off the screen.
  */
 export default function CurriculumNavigator() {
-  const [programs, setPrograms] = useState<Program[]>([]);
+  const programsEndpoint = '/api/programs?pagination=false&order[name]=asc';
+  const [programs, setPrograms] = useState<Program[]>(() => {
+    const preloaded = readPreloadedApi(programsEndpoint) as HydraCollection<unknown> | undefined;
+    return preloaded?.['hydra:member'].map(convertToProgram) ?? [];
+  });
   const [allHits, setAllHits] = useState<CourseHit[] | null>(null);
   const [results, setResults] = useState<CourseHit[] | null>(null);
   const [searching, setSearching] = useState(false);
@@ -55,19 +59,23 @@ export default function CurriculumNavigator() {
   const { user } = useUser();
 
   useEffect(() => {
+    if (programs.length > 0) {
+      initializeFuseInstances([], [], programs);
+      return;
+    }
+
     let cancelled = false;
 
     void (async () => {
-      const result = await requestPrograms('GET', '/api/programs?pagination=false&order[name]=asc');
+      const result = await requestPrograms('GET', programsEndpoint);
       if (cancelled || !result) return;
 
       const fetched = result['hydra:member'].map(convertToProgram);
       setPrograms(fetched);
-      initializeFuseInstances([], [], fetched);
     })();
 
     return () => { cancelled = true; };
-  }, [requestPrograms]);
+  }, [programs, programsEndpoint, requestPrograms]);
 
   // The whole curriculum is only pulled once someone actually searches; browsing stays one
   // request per level.
@@ -141,14 +149,15 @@ export default function CurriculumNavigator() {
                 key={program.id}
                 className="flex items-center gap-2 rounded-[18px] border border-vtk-line bg-vtk-surface px-4 transition-colors hover:border-vtk-line-2 hover:bg-vtk-paper"
               >
-                <Link
+                <ApiPrefetchLink
                   href={curriculumHref.program(program)}
+                  apiEndpoints={`/api/programs/${program.id}`}
                   className="flex min-w-0 flex-1 items-center gap-3 py-3.5 text-[15px] font-medium text-vtk-ink rounded focus:outline-hidden focus-visible:ring-2 focus-visible:ring-vtk-navy"
                 >
                   <GraduationCap size={17} className="shrink-0 text-vtk-muted" aria-hidden="true" />
                   <span className="min-w-0 flex-1 truncate">{program.name}</span>
                   <ChevronRight size={16} className="shrink-0 text-vtk-muted" aria-hidden="true" />
-                </Link>
+                </ApiPrefetchLink>
                 <FavoriteButton itemId={program.id} itemType="program" size={16} className="shrink-0" />
                 <DownloadButton programs={[program]} />
               </div>

--- a/frontend/src/components/curriculum/CurriculumLevel.tsx
+++ b/frontend/src/components/curriculum/CurriculumLevel.tsx
@@ -5,9 +5,9 @@ import { CourseTableHeader } from '@/components/courses/CourseTableHeader';
 import { curriculumHref } from '@/components/curriculum/curriculumLinks';
 import DownloadButton from '@/components/ui/DownloadButton';
 import FavoriteButton from '@/components/ui/FavoriteButton';
+import ApiPrefetchLink from '@/components/ui/ApiPrefetchLink';
 import type { Course, Module } from '@/types/entities';
 import { ChevronRight, Folder } from 'lucide-react';
-import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
 
 interface CurriculumLevelProps {
@@ -48,14 +48,15 @@ export default function CurriculumLevel({ modules, courses, moduleId }: Curricul
                                 key={node.id}
                                 className="flex items-center gap-2 rounded-[14px] border border-vtk-line bg-vtk-surface px-4 transition-colors hover:border-vtk-line-2 hover:bg-vtk-paper"
                             >
-                                <Link
+                                <ApiPrefetchLink
                                     href={curriculumHref.module(node)}
+                                    apiEndpoints={`/api/modules/${node.id}`}
                                     className="flex min-w-0 flex-1 items-center gap-3 py-3 text-[15px] font-medium text-vtk-ink rounded focus:outline-hidden focus-visible:ring-2 focus-visible:ring-vtk-navy"
                                 >
                                     <Folder size={16} className="shrink-0 text-vtk-muted" aria-hidden="true" />
                                     <span className="min-w-0 flex-1 truncate">{node.name}</span>
                                     <ChevronRight size={16} className="shrink-0 text-vtk-muted" aria-hidden="true" />
-                                </Link>
+                                </ApiPrefetchLink>
                                 <FavoriteButton itemId={node.id} itemType="module" size={16} className="shrink-0" />
                                 <DownloadButton modules={[node]} />
                             </div>

--- a/frontend/src/components/curriculum/CurriculumSearchResults.tsx
+++ b/frontend/src/components/curriculum/CurriculumSearchResults.tsx
@@ -4,13 +4,13 @@ import ProfessorDiv from '@/components/coursepage/ProfessorDiv';
 import { curriculumHref } from '@/components/curriculum/curriculumLinks';
 import DownloadButton from '@/components/ui/DownloadButton';
 import FavoriteButton from '@/components/ui/FavoriteButton';
+import ApiPrefetchLink from '@/components/ui/ApiPrefetchLink';
 import SemesterIndicator from '@/components/ui/SemesterIndicator';
 import type { Course, Module, Program } from '@/types/entities';
 import { localizedCourseName } from '@/utils/courseName';
 import { shortProgramName } from '@/utils/curriculumLabels';
 import { rememberBranch } from '@/utils/curriculumBranch';
 import { ChevronRight } from 'lucide-react';
-import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
 
 /** A course together with the one branch this result found it under. */
@@ -48,8 +48,9 @@ export default function CurriculumSearchResults({ hits }: { hits: CourseHit[] })
                         <FavoriteButton itemId={course.id} itemType="course" size={16} className="shrink-0" />
 
                         <div className="min-w-0 flex-1">
-                            <Link
+                            <ApiPrefetchLink
                                 href={curriculumHref.course(course)}
+                                apiEndpoints={`/api/courses/${course.id}`}
                                 onClick={() => {
                                     const leaf = modules.at(-1);
                                     if (leaf) rememberBranch(course.id, leaf.id);
@@ -57,7 +58,7 @@ export default function CurriculumSearchResults({ hits }: { hits: CourseHit[] })
                                 className="block truncate text-[15px] font-semibold tracking-tight text-vtk-ink hover:underline"
                             >
                                 {localizedCourseName(course, language ?? i18n.language)}
-                            </Link>
+                            </ApiPrefetchLink>
 
                             {/* The branch, as breadcrumbs rather than a tree to hunt through. */}
                             <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-1 text-xs text-vtk-muted">

--- a/frontend/src/components/curriculum/CurriculumTree.tsx
+++ b/frontend/src/components/curriculum/CurriculumTree.tsx
@@ -2,14 +2,14 @@
 
 import { useCurriculumLocation } from '@/components/curriculum/CurriculumLocationContext';
 import { curriculumHref } from '@/components/curriculum/curriculumLinks';
-import { HydraCollection, useApi } from '@/hooks/useApi';
+import ApiPrefetchLink from '@/components/ui/ApiPrefetchLink';
+import { HydraCollection, readPreloadedApi, useApi } from '@/hooks/useApi';
 import { useSiblingDocuments } from '@/hooks/useSiblingDocuments';
 import type { Course, DocumentCategory, Module, Program } from '@/types/entities';
 import { convertToDocumentCategory, convertToModule, convertToProgram } from '@/utils/convertToEntity';
 import { localizedCourseName } from '@/utils/courseName';
 import { treeProgramName } from '@/utils/curriculumLabels';
 import { ChevronRight, File, FileText, Folder, GraduationCap, LoaderCircle } from 'lucide-react';
-import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -42,7 +42,11 @@ export default function CurriculumTree() {
     const { request } = useApi<unknown>();
     const { program, module, course, category, document, activePath } = useCurriculumLocation();
 
-    const [programs, setPrograms] = useState<Program[]>([]);
+    const programsEndpoint = '/api/programs?pagination=false&order[name]=asc';
+    const [programs, setPrograms] = useState<Program[]>(() => {
+        const preloaded = readPreloadedApi(programsEndpoint) as HydraCollection<unknown> | undefined;
+        return preloaded?.['hydra:member'].map(convertToProgram) ?? [];
+    });
     const [programChildren, setProgramChildren] = useState<Record<number, Module[]>>({});
     const [moduleChildren, setModuleChildren] = useState<Record<number, ModuleChildren>>({});
     const [loadingKeys, setLoadingKeys] = useState<Set<NodeKey>>(new Set());
@@ -50,10 +54,12 @@ export default function CurriculumTree() {
     const inFlight = useRef<Set<NodeKey>>(new Set());
 
     useEffect(() => {
+        if (programs.length > 0) return;
+
         let cancelled = false;
 
         void (async () => {
-            const result = await request('GET', '/api/programs?pagination=false&order[name]=asc') as HydraCollection<unknown> | null;
+            const result = await request('GET', programsEndpoint) as HydraCollection<unknown> | null;
             if (cancelled) return;
 
             const members = result?.['hydra:member'];
@@ -61,7 +67,7 @@ export default function CurriculumTree() {
         })();
 
         return () => { cancelled = true; };
-    }, [request]);
+    }, [programs.length, programsEndpoint, request]);
 
     const markLoading = useCallback((key: NodeKey, loading: boolean) => {
         setLoadingKeys((previous) => {
@@ -191,6 +197,7 @@ export default function CurriculumTree() {
                 <TreeRow
                     label={node.name ?? ''}
                     href={curriculumHref.module(node)}
+                    apiEndpoints={`/api/modules/${node.id}`}
                     depth={depth}
                     icon={Folder}
                     open={isOpen}
@@ -222,6 +229,7 @@ export default function CurriculumTree() {
                 <TreeRow
                     label={localizedCourseName(node, i18n.language) ?? node.code ?? ''}
                     href={curriculumHref.course(node)}
+                    apiEndpoints={`/api/courses/${node.id}`}
                     depth={depth}
                     icon={FileText}
                     open={isOpen}
@@ -238,6 +246,10 @@ export default function CurriculumTree() {
                             <TreeRow
                                 label={item.name ?? ''}
                                 href={`/course/${node.id}/documents/category/${item.id}`}
+                                apiEndpoints={[
+                                    `/api/courses/${node.id}?summary=true`,
+                                    `/api/document_categories/${item.id}?lang=${i18n.language}`,
+                                ]}
                                 depth={depth + 1}
                                 icon={Folder}
                                 open={isCurrentCategory}
@@ -249,6 +261,7 @@ export default function CurriculumTree() {
                                     key={`d${file.id}`}
                                     label={file.name ?? file.filename ?? ''}
                                     href={`/document/${file.id}`}
+                                    apiEndpoints={`/api/documents/${file.id}?lang=${i18n.language}`}
                                     depth={depth + 2}
                                     icon={File}
                                     active={activeKey === `d${file.id}`}
@@ -274,6 +287,7 @@ export default function CurriculumTree() {
                             label={treeProgramName(node.name)}
                             title={node.name}
                             href={curriculumHref.program(node)}
+                            apiEndpoints={`/api/programs/${node.id}`}
                             depth={0}
                             icon={GraduationCap}
                             open={isOpen}
@@ -298,6 +312,7 @@ interface TreeRowProps {
     label: string;
     title?: string;
     href: string;
+    apiEndpoints?: string | string[];
     depth: number;
     icon: typeof Folder;
     open?: boolean;
@@ -316,7 +331,7 @@ interface TreeRowProps {
  * the other.
  */
 function TreeRow({
-    label, title, href, depth, icon: Icon, open = false,
+    label, title, href, apiEndpoints, depth, icon: Icon, open = false,
     expandable = false, active = false, loading = false, badge, onToggle,
 }: TreeRowProps) {
     const { t } = useTranslation();
@@ -356,8 +371,9 @@ function TreeRow({
                 <span className="h-8 w-8 shrink-0" aria-hidden="true" />
             )}
 
-            <Link
+            <ApiPrefetchLink
                 href={href}
+                apiEndpoints={apiEndpoints}
                 title={title ?? label}
                 aria-current={active ? 'page' : undefined}
                 className="flex min-w-0 self-stretch flex-1 items-center gap-1.5 pr-1 rounded focus:outline-hidden focus-visible:ring-2 focus-visible:ring-vtk-navy"
@@ -369,7 +385,7 @@ function TreeRow({
                 {badge !== undefined && badge > 0 && (
                     <span className="shrink-0 text-[11px] tabular-nums text-vtk-muted">{badge}</span>
                 )}
-            </Link>
+            </ApiPrefetchLink>
         </div>
     );
 }

--- a/frontend/src/components/curriculum/ModulePage.tsx
+++ b/frontend/src/components/curriculum/ModulePage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Loading from '@/app/[locale]/loading';
+import Loading from '@/components/loading/LoadingPage';
 import { ProgramLanguageProvider } from '@/components/courses/ProgramLanguageContext';
 import CurriculumLevel from '@/components/curriculum/CurriculumLevel';
 import { usePublishCurriculumLocation } from '@/components/curriculum/CurriculumLocationContext';
@@ -9,7 +9,7 @@ import DownloadButton from '@/components/ui/DownloadButton';
 import DynamicBreadcrumb from '@/components/ui/DynamicBreadcrumb';
 import FavoriteButton from '@/components/ui/FavoriteButton';
 import PageHead from '@/components/ui/PageHead';
-import { useApi } from '@/hooks/useApi';
+import { readPreloadedApi, useApi } from '@/hooks/useApi';
 import type { Module } from '@/types/entities';
 import { convertToModule } from '@/utils/convertToEntity';
 import { Folder } from 'lucide-react';
@@ -19,19 +19,25 @@ import { useTranslation } from 'react-i18next';
 export default function ModulePage({ id }: { id: number }) {
     const { t } = useTranslation();
     const { request, loading, error } = useApi<unknown>();
-    const [module, setModule] = useState<Module | null>(null);
+    const endpoint = `/api/modules/${id}`;
+    const [module, setModule] = useState<Module | null>(() => {
+        const preloaded = readPreloadedApi(endpoint);
+        return preloaded ? convertToModule(preloaded) : null;
+    });
 
     useEffect(() => {
+        if (module?.id === id) return;
+
         let cancelled = false;
 
         void (async () => {
-            const data = await request('GET', `/api/modules/${id}`);
+            const data = await request('GET', endpoint);
             if (cancelled || !data) return;
             setModule(convertToModule(data));
         })();
 
         return () => { cancelled = true; };
-    }, [id, request]);
+    }, [endpoint, id, module?.id, request]);
 
     usePublishCurriculumLocation({ module: module ?? undefined });
 

--- a/frontend/src/components/curriculum/ProgramPage.tsx
+++ b/frontend/src/components/curriculum/ProgramPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Loading from '@/app/[locale]/loading';
+import Loading from '@/components/loading/LoadingPage';
 import { ProgramLanguageProvider } from '@/components/courses/ProgramLanguageContext';
 import CurriculumLevel from '@/components/curriculum/CurriculumLevel';
 import { usePublishCurriculumLocation } from '@/components/curriculum/CurriculumLocationContext';
@@ -8,7 +8,7 @@ import ErrorPage from '@/components/error/ErrorPage';
 import DynamicBreadcrumb from '@/components/ui/DynamicBreadcrumb';
 import FavoriteButton from '@/components/ui/FavoriteButton';
 import PageHead from '@/components/ui/PageHead';
-import { useApi } from '@/hooks/useApi';
+import { readPreloadedApi, useApi } from '@/hooks/useApi';
 import type { Program } from '@/types/entities';
 import { convertToProgram } from '@/utils/convertToEntity';
 import { programQualifier, shortProgramName } from '@/utils/curriculumLabels';
@@ -18,19 +18,25 @@ import { useTranslation } from 'react-i18next';
 export default function ProgramPage({ id }: { id: number }) {
     const { t } = useTranslation();
     const { request, loading, error } = useApi<unknown>();
-    const [program, setProgram] = useState<Program | null>(null);
+    const endpoint = `/api/programs/${id}`;
+    const [program, setProgram] = useState<Program | null>(() => {
+        const preloaded = readPreloadedApi(endpoint);
+        return preloaded ? convertToProgram(preloaded) : null;
+    });
 
     useEffect(() => {
+        if (program?.id === id) return;
+
         let cancelled = false;
 
         void (async () => {
-            const data = await request('GET', `/api/programs/${id}`);
+            const data = await request('GET', endpoint);
             if (cancelled || !data) return;
             setProgram(convertToProgram(data));
         })();
 
         return () => { cancelled = true; };
-    }, [id, request]);
+    }, [endpoint, id, program?.id, request]);
 
     usePublishCurriculumLocation({ program: program ?? undefined });
 

--- a/frontend/src/components/document/DocumentPreview.tsx
+++ b/frontend/src/components/document/DocumentPreview.tsx
@@ -14,7 +14,7 @@ import PageHead from "@/components/ui/PageHead";
 import FavoriteButton from "@/components/ui/FavoriteButton";
 import { useUser } from "@/components/UserContext";
 import { logDocumentView } from "@/hooks/logDocumentView";
-import { useApi } from "@/hooks/useApi";
+import { readPreloadedApi, useApi } from "@/hooks/useApi";
 import type { Document } from "@/types/entities";
 import { convertToDocument } from "@/utils/convertToEntity";
 import { formatFileSize } from "@/utils/fileSize";
@@ -28,8 +28,13 @@ import { useTranslation } from "react-i18next";
 const PDFViewer = dynamic(() => import("@/components/document/pdf/PDFViewer"), { ssr: false });
 
 export default function DocumentPreview({ id }: { id: string }) {
-
-    const [document, setDocument] = useState<Document | null>(null);
+    const { t, i18n } = useTranslation();
+    const currentLocale = i18n.language;
+    const endpoint = `/api/documents/${id}?lang=${currentLocale}`;
+    const [document, setDocument] = useState<Document | null>(() => {
+        const preloaded = readPreloadedApi(endpoint);
+        return preloaded ? convertToDocument(preloaded) : null;
+    });
 
     // Used to scale pdf width to fit its parent container
     const [containerWidth, setContainerWidth] = useState<number>(0);
@@ -37,14 +42,13 @@ export default function DocumentPreview({ id }: { id: string }) {
 
     const { user } = useUser();
     const { request, loading, error } = useApi();
-    const { t } = useTranslation();
-    const { i18n } = useTranslation();
-    const currentLocale = i18n.language;
     const MAXWIDTH = 1000;
 
     useEffect(() => {
+        if (document?.id === Number(id)) return;
+
         const fetchDocumentData = async () => {
-            const documentData = await request('GET', `/api/documents/${id}?lang=${currentLocale}`);
+            const documentData = await request('GET', endpoint);
             if (!documentData) {
                 return null;
             }
@@ -52,7 +56,7 @@ export default function DocumentPreview({ id }: { id: string }) {
         };
 
         fetchDocumentData();
-    }, [id, request, currentLocale]);
+    }, [document?.id, endpoint, id, request]);
 
     useEffect(() => {
         logDocumentView(id);

--- a/frontend/src/components/document/DocumentSiblingNav.tsx
+++ b/frontend/src/components/document/DocumentSiblingNav.tsx
@@ -2,8 +2,8 @@
 
 import { useSiblingDocuments } from '@/hooks/useSiblingDocuments';
 import type { Document } from '@/types/entities';
+import ApiPrefetchLink from '@/components/ui/ApiPrefetchLink';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
 
 /**
@@ -14,7 +14,7 @@ import { useTranslation } from 'react-i18next';
  * tiebreaker - so "next" means what the list said it would.
  */
 export default function DocumentSiblingNav({ document }: { document: Document }) {
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
     const { documents } = useSiblingDocuments(document.course?.id, document.category?.id);
 
     const index = documents.findIndex((sibling) => sibling.id === document.id);
@@ -33,14 +33,15 @@ export default function DocumentSiblingNav({ document }: { document: Document })
     return (
         <div className="flex items-center gap-1.5">
             {previous ? (
-                <Link
+                <ApiPrefetchLink
                     href={`/document/${previous.id}`}
+                    apiEndpoints={`/api/documents/${previous.id}?lang=${i18n.language}`}
                     className={arrow}
                     title={previous.name ?? t('document.siblings.previous')}
                     aria-label={t('document.siblings.previous')}
                 >
                     <ChevronLeft size={16} />
-                </Link>
+                </ApiPrefetchLink>
             ) : (
                 <span className={`${arrow} ${disabled}`} aria-hidden="true">
                     <ChevronLeft size={16} />
@@ -52,14 +53,15 @@ export default function DocumentSiblingNav({ document }: { document: Document })
             </span>
 
             {next ? (
-                <Link
+                <ApiPrefetchLink
                     href={`/document/${next.id}`}
+                    apiEndpoints={`/api/documents/${next.id}?lang=${i18n.language}`}
                     className={arrow}
                     title={next.name ?? t('document.siblings.next')}
                     aria-label={t('document.siblings.next')}
                 >
                     <ChevronRight size={16} />
-                </Link>
+                </ApiPrefetchLink>
             ) : (
                 <span className={`${arrow} ${disabled}`} aria-hidden="true">
                     <ChevronRight size={16} />

--- a/frontend/src/components/documentcategorypage/DocumentListItem.tsx
+++ b/frontend/src/components/documentcategorypage/DocumentListItem.tsx
@@ -2,11 +2,11 @@ import Badge from '@/components/ui/Badge';
 import { Checkbox } from '@/components/ui/Checkbox';
 import DownloadButton from '@/components/ui/DownloadButton';
 import FavoriteButton from '@/components/ui/FavoriteButton';
+import ApiPrefetchLink from '@/components/ui/ApiPrefetchLink';
 import VoteButton from '@/components/ui/buttons/VoteButton';
 import type { Document } from '@/types/entities';
 import { inlineUrl, previewKindFor } from '@/utils/previewableFile';
 import { ExternalLink, Tag as TagIcon } from 'lucide-react';
-import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
 
 interface DocumentListItemProps {
@@ -16,7 +16,7 @@ interface DocumentListItemProps {
 }
 
 const DocumentListItem: React.FC<DocumentListItemProps> = ({ document, isSelected, onToggleSelect }) => {
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
 
     const uploader = document.anonymous
         ? t('course-page.documents.anonymous')
@@ -46,12 +46,13 @@ const DocumentListItem: React.FC<DocumentListItemProps> = ({ document, isSelecte
             />
 
             <div className="min-w-0 flex-1 basis-[min(100%,16rem)]">
-                <Link
+                <ApiPrefetchLink
                     href={`/document/${document.id}`}
+                    apiEndpoints={`/api/documents/${document.id}?lang=${i18n.language}`}
                     className="block truncate text-[15px] font-semibold tracking-tight text-vtk-ink hover:underline"
                 >
                     {document.name}
-                </Link>
+                </ApiPrefetchLink>
                 {/* Display tags if they exist */}
                 {document.tags && document.tags.length > 0 && (
                     <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-vtk-muted">

--- a/frontend/src/components/documentcategorypage/FavoriteDocuments.tsx
+++ b/frontend/src/components/documentcategorypage/FavoriteDocuments.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Loading from '@/app/[locale]/loading';
+import Loading from '@/components/loading/LoadingPage';
 import Badge from '@/components/ui/Badge';
 import DownloadButton from '@/components/ui/DownloadButton';
 import FavoriteButton from '@/components/ui/FavoriteButton';

--- a/frontend/src/components/homepage/FavoriteCurriculum.tsx
+++ b/frontend/src/components/homepage/FavoriteCurriculum.tsx
@@ -3,6 +3,7 @@
 import { useUser } from '@/components/UserContext';
 import { curriculumHref } from '@/components/curriculum/curriculumLinks';
 import FavoriteButton from '@/components/ui/FavoriteButton';
+import ApiPrefetchLink from '@/components/ui/ApiPrefetchLink';
 import { GraduationCap, Layers } from 'lucide-react';
 import Link from 'next/link';
 import type { LucideIcon } from 'lucide-react';
@@ -23,16 +24,17 @@ const FavoriteRow = ({ id, name, typeLabel, type, icon: Icon }: FavoriteRowProps
     // The star has to sit outside the link — a button nested in an anchor is invalid markup —
     // so it is overlaid on the row instead, the same way the sidebar favourites do it.
     <div className="group relative">
-        <Link
+        <ApiPrefetchLink
             className="flex items-center gap-3.5 px-5 py-2.5 pr-12 transition-colors hover:bg-vtk-paper-2"
             href={type === 'program' ? curriculumHref.program({ id }) : curriculumHref.module({ id })}
+            apiEndpoints={type === 'program' ? `/api/programs/${id}` : `/api/modules/${id}`}
         >
             <Icon aria-hidden="true" className="h-4 w-4 shrink-0 text-vtk-muted" />
             <div className="min-w-0 flex-1">
                 <p className="truncate text-sm font-medium leading-snug text-vtk-ink">{name}</p>
                 <p className="truncate text-[13px] leading-snug text-vtk-muted">{typeLabel}</p>
             </div>
-        </Link>
+        </ApiPrefetchLink>
         <div className="absolute inset-y-0 right-4 flex items-center opacity-0 transition-opacity duration-100 focus-within:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100">
             <FavoriteButton itemId={id} itemType={type} size={16} />
         </div>

--- a/frontend/src/components/homepage/recent/RecentActivities.tsx
+++ b/frontend/src/components/homepage/recent/RecentActivities.tsx
@@ -1,4 +1,4 @@
-import Loading from '@/app/[locale]/loading';
+import Loading from '@/components/loading/LoadingPage';
 import { Activity } from '@/components/homepage/recent/Activity';
 import { HydraCollection, useApi } from '@/hooks/useApi';
 import type { DocumentView } from '@/types/entities';

--- a/frontend/src/components/layout/ItemList.tsx
+++ b/frontend/src/components/layout/ItemList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import Link from 'next/link';
+import ApiPrefetchLink from '@/components/ui/ApiPrefetchLink';
 import FavoriteButton from '@/components/ui/FavoriteButton';
+import { useTranslation } from 'react-i18next';
 
 interface Item {
     id: number;
@@ -16,8 +17,15 @@ interface ItemListProps {
 }
 
 const ItemList: React.FC<ItemListProps> = ({ items, emptyMessage }) => {
+    const { i18n } = useTranslation();
     const itemsPerList = 10;
     const displayedItems = items.slice(0, itemsPerList);
+    const apiEndpointFor = (item: Item) => {
+        if (item.type === 'program') return `/api/programs/${item.id}`;
+        if (item.type === 'module') return `/api/modules/${item.id}`;
+        if (item.type === 'course') return `/api/courses/${item.id}`;
+        return `/api/documents/${item.id}?lang=${i18n.language}`;
+    };
 
     return (
         <div className="pl-2">
@@ -28,8 +36,9 @@ const ItemList: React.FC<ItemListProps> = ({ items, emptyMessage }) => {
                             key={`${item.type}-${item.id}`}
                             className="group relative rounded-lg transition-colors duration-100 hover:bg-vtk-paper-2"
                         >
-                            <Link
+                            <ApiPrefetchLink
                                 href={item.redirectUrl}
+                                apiEndpoints={apiEndpointFor(item)}
                                 className="flex w-full min-w-0 items-center rounded-lg px-2 py-1.5 pr-9 focus-visible:ring-2 focus-visible:ring-vtk-ink/20"
                             >
                                 <div className="flex min-w-0 items-center overflow-hidden">
@@ -38,7 +47,7 @@ const ItemList: React.FC<ItemListProps> = ({ items, emptyMessage }) => {
                                         {item.code && <span className="ml-1 text-xs text-vtk-muted">({item.code})</span>}
                                     </span>
                                 </div>
-                            </Link>
+                            </ApiPrefetchLink>
                             <div className="absolute inset-y-0 right-2 z-10 flex items-center opacity-0 transition-opacity duration-100 focus-within:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100">
                                 <FavoriteButton
                                     itemId={item.id}
@@ -55,12 +64,12 @@ const ItemList: React.FC<ItemListProps> = ({ items, emptyMessage }) => {
                 <p className="px-2 py-1 text-[13px] leading-snug text-vtk-muted">{emptyMessage}</p>
             )}
             {items.length > itemsPerList && (
-                <Link
+                <ApiPrefetchLink
                     href="/account"
                     className="mt-1 block rounded-lg px-2 py-1 text-[13px] text-vtk-muted transition-colors duration-100 hover:bg-vtk-paper-2 hover:text-vtk-ink"
                 >
                     View All
-                </Link>
+                </ApiPrefetchLink>
             )}
         </div>
     );

--- a/frontend/src/components/page/PageContent.tsx
+++ b/frontend/src/components/page/PageContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Loading from "@/app/[locale]/loading";
+import Loading from "@/components/loading/LoadingPage";
 import ErrorPage from "@/components/error/ErrorPage";
 import PageHead from "@/components/ui/PageHead";
 import { useApi } from "@/hooks/useApi";

--- a/frontend/src/components/search/SearchPopup.tsx
+++ b/frontend/src/components/search/SearchPopup.tsx
@@ -10,6 +10,7 @@ import type { Course, Document, Module, Program } from '@/types/entities';
 import { convertToCourse, convertToDocument, convertToModule, convertToProgram } from '@/utils/convertToEntity';
 import { Combobox, ComboboxInput, ComboboxOptions, Dialog, DialogBackdrop, DialogPanel, } from '@headlessui/react';
 import { Frown, Globe, Search as SearchIcon } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -33,6 +34,7 @@ export default function SearchPopup({ open, setOpen }: SearchPopupProps) {
     const [items, setItems] = useState<SearchResults>({ courses: [], modules: [], programs: [], documents: [] });
     const { error, loading, isRedirecting, request } = useApi<SearchApiResponse | null>();
     const { t } = useTranslation();
+    const router = useRouter();
 
     function convertToObjects(obj: SearchApiResponse): SearchResults {
         const items: SearchResults = { courses: [], modules: [], programs: [], documents: [] };
@@ -103,11 +105,11 @@ export default function SearchPopup({ open, setOpen }: SearchPopupProps) {
                     className="mx-auto max-w-xl transform overflow-hidden rounded-[22px] border border-vtk-line bg-vtk-surface shadow-[0_24px_70px_rgba(10,15,31,0.2)] transition-all data-closed:scale-95 data-closed:opacity-0 data-enter:duration-300 data-leave:duration-200 data-enter:ease-out data-leave:ease-in"
                 >
                     <Combobox
-                        onChange={(param: { redirect: Location | string } | null) => {
+                        onChange={(param: { redirect: string } | null) => {
                             if (param?.redirect) {
-                                window.location.href = typeof param.redirect === 'string'
-                                    ? param.redirect
-                                    : param.redirect.href;
+                                setOpen(false);
+                                setQuery('');
+                                router.push(param.redirect);
                             }
                         }}
                     >
@@ -122,7 +124,6 @@ export default function SearchPopup({ open, setOpen }: SearchPopupProps) {
                                     className="h-12 w-full border-0 bg-transparent pl-11 pr-4 text-vtk-ink placeholder:text-vtk-muted focus:ring-0 sm:text-sm"
                                     placeholder={t('search.placeholder')}
                                     onChange={(event) => setQuery(event.target.value)}
-                                    onBlur={() => setQuery('')}
                                 />
                             </div>
 

--- a/frontend/src/components/search/SearchResult.tsx
+++ b/frontend/src/components/search/SearchResult.tsx
@@ -4,16 +4,27 @@ import clsx from "clsx";
 import { useTranslation } from 'react-i18next';
 import { localizedCourseName } from '@/utils/courseName';
 import { curriculumHref } from '@/components/curriculum/curriculumLinks';
+import { preloadApi } from '@/hooks/useApi';
+import { useRouter } from 'next/navigation';
 
 type SearchResultProps = {
     mainResult: string;
     extraInfo?: string;
     redirect: string;
+    apiEndpoint?: string;
 };
 
-export default function SearchResult({ mainResult, extraInfo, redirect }: SearchResultProps) {
+export default function SearchResult({ mainResult, extraInfo, redirect, apiEndpoint }: SearchResultProps) {
+    const router = useRouter();
+    const prefetch = () => {
+        router.prefetch(redirect);
+        if (apiEndpoint) preloadApi(apiEndpoint);
+    };
+
     return <ComboboxOption
-        value={{ redirect }}
+        value={{ redirect, apiEndpoint }}
+        onMouseEnter={prefetch}
+        onFocus={prefetch}
         className="cursor-default select-none px-4 py-2 data-focus:bg-vtk-ink data-focus:text-white"
     >
         {({ focus }) => (<div className="flex justify-between">
@@ -29,22 +40,22 @@ export default function SearchResult({ mainResult, extraInfo, redirect }: Search
 export function CourseSearchResult({ course }: { course: Course }) {
     const { t, i18n } = useTranslation();
     return <SearchResult mainResult={localizedCourseName(course, i18n.language) || course.name || course.code || `${t('curriculum-navigator.course', { defaultValue: 'Vak' })} #${course.id}`} extraInfo={course.code}
-        redirect={curriculumHref.course(course)} />
+        redirect={curriculumHref.course(course)} apiEndpoint={`/api/courses/${course.id}`} />
 }
 
 export function ModuleSearchResult({ module }: { module: Module }) {
     const { t } = useTranslation();
     return <SearchResult mainResult={module.name || `${t('curriculum-navigator.module', { defaultValue: 'Module' })} #${module.id}`} extraInfo={module.program?.name}
-        redirect={curriculumHref.module(module)} />
+        redirect={curriculumHref.module(module)} apiEndpoint={`/api/modules/${module.id}`} />
 }
 
 export function ProgramSearchResult({ program }: { program: Program }) {
     const { t } = useTranslation();
-    return <SearchResult mainResult={program.name || `${t('curriculum-navigator.program', { defaultValue: 'Richting' })} #${program.id}`} redirect={curriculumHref.program(program)} />
+    return <SearchResult mainResult={program.name || `${t('curriculum-navigator.program', { defaultValue: 'Richting' })} #${program.id}`} redirect={curriculumHref.program(program)} apiEndpoint={`/api/programs/${program.id}`} />
 }
 
 export function DocumentSearchResult({ document }: { document: Document }) {
     const { i18n } = useTranslation();
     return <SearchResult mainResult={document.name || document.filename || `Document #${document.id}`} extraInfo={localizedCourseName(document.course, i18n.language)}
-        redirect={"/document/" + document.id} />
+        redirect={"/document/" + document.id} apiEndpoint={`/api/documents/${document.id}?lang=${i18n.language}`} />
 }

--- a/frontend/src/components/ui/ApiPrefetchLink.tsx
+++ b/frontend/src/components/ui/ApiPrefetchLink.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { preloadApi } from '@/hooks/useApi';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect, useRef, type ComponentProps, type FocusEvent, type MouseEvent, type TouchEvent } from 'react';
+
+type Props = ComponentProps<typeof Link> & {
+    apiEndpoints?: string | string[];
+};
+
+/**
+ * A normal Next link that also warms the API data its destination will request. Mouse, keyboard
+ * and touch users all start the request before navigation, and useApi deduplicates the eventual
+ * page request against it.
+ */
+export default function ApiPrefetchLink({
+    apiEndpoints,
+    href,
+    onMouseEnter,
+    onMouseLeave,
+    onFocus,
+    onTouchStart,
+    ...props
+}: Props) {
+    const router = useRouter();
+    const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const warm = () => {
+        if (typeof href === 'string') router.prefetch(href);
+
+        const endpoints = Array.isArray(apiEndpoints) ? apiEndpoints : [apiEndpoints];
+        endpoints.forEach((endpoint) => {
+            if (endpoint) preloadApi(endpoint);
+        });
+    };
+
+    const handleMouseEnter = (event: MouseEvent<HTMLAnchorElement>) => {
+        hoverTimer.current = setTimeout(warm, 80);
+        onMouseEnter?.(event);
+    };
+
+    const handleMouseLeave = (event: MouseEvent<HTMLAnchorElement>) => {
+        if (hoverTimer.current) clearTimeout(hoverTimer.current);
+        hoverTimer.current = null;
+        onMouseLeave?.(event);
+    };
+
+    const handleFocus = (event: FocusEvent<HTMLAnchorElement>) => {
+        if (hoverTimer.current) clearTimeout(hoverTimer.current);
+        warm();
+        onFocus?.(event);
+    };
+
+    const handleTouchStart = (event: TouchEvent<HTMLAnchorElement>) => {
+        if (hoverTimer.current) clearTimeout(hoverTimer.current);
+        warm();
+        onTouchStart?.(event);
+    };
+
+    useEffect(() => () => {
+        if (hoverTimer.current) clearTimeout(hoverTimer.current);
+    }, []);
+
+    return (
+        <Link
+            {...props}
+            href={href}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+            onFocus={handleFocus}
+            onTouchStart={handleTouchStart}
+        />
+    );
+}

--- a/frontend/src/hooks/useApi.tsx
+++ b/frontend/src/hooks/useApi.tsx
@@ -7,6 +7,73 @@ import { useCallback, useState } from 'react';
 
 type ApiErrorBody = { message?: string; detail?: string; status?: number };
 
+type CachedGet = {
+    value: unknown;
+    expiresAt: number;
+};
+
+const GET_CACHE_TTL_MS = 30_000;
+const getCache = new Map<string, CachedGet>();
+const pendingGets = new Map<string, Promise<unknown>>();
+
+/**
+ * Curriculum structure and document listings are read repeatedly by the page, breadcrumb and
+ * sidebar. Keeping them briefly in the browser removes those duplicate round trips while still
+ * letting edits become visible quickly. Mutations clear the cache immediately below.
+ */
+const isCacheableGet = (endpoint: string): boolean => (
+    endpoint.startsWith('/api/programs')
+    || /^\/api\/modules\/\d+(?:$|\?|\/path(?:$|\?))/.test(endpoint)
+    || /^\/api\/courses\/\d+(?:$|\?|\/paths(?:$|\?))/.test(endpoint)
+    || endpoint.startsWith('/api/document_categories')
+    || endpoint.startsWith('/api/documents?')
+    || /^\/api\/documents\/\d+(?:$|\?)/.test(endpoint)
+);
+
+const freshCachedValue = (endpoint: string): unknown | undefined => {
+    const cached = getCache.get(endpoint);
+    if (!cached) return undefined;
+
+    if (cached.expiresAt <= Date.now()) {
+        getCache.delete(endpoint);
+        return undefined;
+    }
+
+    return cached.value;
+};
+
+const getWithDedupe = async (endpoint: string): Promise<unknown> => {
+    if (isCacheableGet(endpoint)) {
+        const cached = freshCachedValue(endpoint);
+        if (cached !== undefined) return cached;
+    }
+
+    const pending = pendingGets.get(endpoint);
+    if (pending) return pending;
+
+    const request = ApiClient('GET', endpoint);
+    pendingGets.set(endpoint, request);
+
+    try {
+        const result = await request;
+        if (isCacheableGet(endpoint) && result !== null && !isErrorResponse(result)) {
+            getCache.set(endpoint, { value: result, expiresAt: Date.now() + GET_CACHE_TTL_MS });
+        }
+        return result;
+    } finally {
+        pendingGets.delete(endpoint);
+    }
+};
+
+/** Start a cacheable API request before the reader clicks. */
+export const preloadApi = (endpoint: string): void => {
+    if (!isCacheableGet(endpoint)) return;
+    void getWithDedupe(endpoint).catch(() => { });
+};
+
+/** Lets a destination render cached data on its very first frame instead of flashing a spinner. */
+export const readPreloadedApi = (endpoint: string): unknown | undefined => freshCachedValue(endpoint);
+
 export type HydraCollection<T> = {
     'hydra:member': T[];
     'hydra:totalItems': number;
@@ -37,7 +104,10 @@ export function useApi<T = unknown>() {
         setIsRedirecting(false);
 
         try {
-            const result = await ApiClient(method, endpoint, body, customHeaders);
+            const isPlainGet = method.toUpperCase() === 'GET' && body === undefined && customHeaders === undefined;
+            const result = isPlainGet
+                ? await getWithDedupe(endpoint)
+                : await ApiClient(method, endpoint, body, customHeaders);
 
             // Check if the response contains an error
             if (isErrorResponse(result)) {
@@ -58,6 +128,10 @@ export function useApi<T = unknown>() {
             if (result === null) {
                 setData(null);
                 return null;
+            }
+
+            if (!isPlainGet) {
+                getCache.clear();
             }
 
             // Success case

--- a/frontend/tests/visual.spec.ts
+++ b/frontend/tests/visual.spec.ts
@@ -123,6 +123,19 @@ test('walk the curriculum', async ({ page, context }) => {
   expect(programmeRowHeights.length).toBeGreaterThan(0);
   expect(Math.max(...programmeRowHeights), 'programme names should stay on one row').toBeLessThanOrEqual(32);
 
+  // Selecting a global-search result must stay inside the Next app. A location assignment used
+  // to reload the document, rebuild the complete sidebar and throw away every warmed response.
+  const initialTimeOrigin = await page.evaluate(() => performance.timeOrigin);
+  await page.locator('#search').click();
+  const searchDialog = page.getByRole('dialog');
+  await searchDialog.getByRole('combobox').fill('Polymer Composites A&B');
+  await searchDialog.getByText('Polymer Composites A&B', { exact: true }).first().click();
+  await page.waitForURL(/\/course\/\d+/);
+  expect(await page.evaluate(() => performance.timeOrigin), 'global search should not reload the document')
+    .toBe(initialTimeOrigin);
+  await page.goBack();
+  await settle(page);
+
   // A programme is one click and a real page, not an accordion.
   await page.locator('main').getByRole('link', { name: /Bachelor in de ingenieurswetenschappen/ }).click();
   await page.waitForURL(/\/courses\/program\/\d+/);


### PR DESCRIPTION
## Summary
- deduplicate concurrent GETs and keep curriculum/document payloads in a short-lived client cache
- prefetch dynamic routes and their API data on deliberate hover, focus, or touch while preserving Next client navigation
- keep the current application shell visible during route transitions instead of replacing it with a full-page spinner
- navigate from global search with the App Router instead of forcing a document reload
- add a browser regression assertion that search navigation preserves the current document

## Transfer impact
- duplicate page/sidebar requests share a single in-flight request
- revisiting a curriculum or document endpoint within 30 seconds reuses its response
- mutations invalidate the cache immediately
- mouse prefetch waits for 80 ms of hover intent to avoid transferring destinations that users merely pass over

## Verification
- `npm run lint` (0 errors; one pre-existing LoginForm warning)
- `npm run build`
- `npm run test:a11y` (6 passed)