### PR TITLE
feat(document): tuck comments on compact layouts

### DIFF
--- a/frontend/src/components/document/DocumentCommentSection.tsx
+++ b/frontend/src/components/document/DocumentCommentSection.tsx
@@ -3,21 +3,29 @@ import DocumentComment from "@/components/document/DocumentComment";
 import { HydraCollection, readPreloadedApi, useApi } from "@/hooks/useApi";
 import type { DocumentComment as DocumentCommentEntity } from "@/types/entities";
 import { convertToDocumentComment } from "@/utils/convertToEntity";
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from "@headlessui/react";
+import { MessageSquarePlus, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 interface DocumentCommentSectionProps {
     documentId: number;
     file?: string;
+    displayInline: boolean;
 }
 
-export default function DocumentCommentSection({ documentId, file }: DocumentCommentSectionProps) {
+export default function DocumentCommentSection({
+    documentId,
+    file,
+    displayInline,
+}: DocumentCommentSectionProps) {
     const commentsEndpoint = `/api/document_comments?document=/api/documents/${documentId}`;
     const [comments, setComments] = useState<DocumentCommentEntity[]>(() => {
         const preloaded = readPreloadedApi(commentsEndpoint) as HydraCollection<unknown> | undefined;
         return preloaded?.['hydra:member'] ? preloaded['hydra:member'].map(convertToDocumentComment) : [];
     });
-    const { request } = useApi<HydraCollection<unknown>>();
+    const [isOpen, setIsOpen] = useState(false);
+    const { request, loading } = useApi<HydraCollection<unknown>>();
     const { t } = useTranslation();
 
     useEffect(() => {
@@ -40,31 +48,100 @@ export default function DocumentCommentSection({ documentId, file }: DocumentCom
         setComments(prevComments => [...prevComments, newComment]);
     }, []);
 
-    return (
-        <div className="vtk-panel p-5">
-            <h2 className="m-0 mb-4 text-base font-semibold tracking-tight text-vtk-ink">
-                {t('document.comments.title')}
-                <span className="ml-2 text-[13px] font-normal text-vtk-muted">({comments.length})</span>
-            </h2>
+    const commentsBody = (
+        <div className="space-y-3">
+            {/*Allow users to add comments*/}
+            <AddDocumentCommentBox
+                documentId={documentId}
+                file={file}
+                onCommentAdded={handleCommentAdded}
+            />
 
-            <div className="space-y-3">
-                {/*Allow users to add comments*/}
-                <AddDocumentCommentBox
-                    documentId={documentId}
-                    file={file}
-                    onCommentAdded={handleCommentAdded}
+            {/*Display existing comments*/}
+            {comments.map((comment) => (
+                <DocumentComment
+                    key={comment.id}
+                    id={comment.id}
+                    author={comment.creator?.fullName || t("document.anonymous")}
+                    content={comment.content ?? ''}
                 />
-
-                {/*Display existing comments*/}
-                {comments.map((comment) => (
-                    <DocumentComment
-                        key={comment.id}
-                        id={comment.id}
-                        author={comment.creator?.fullName || t("document.anonymous")}
-                        content={comment.content ?? ''}
-                    />
-                ))}
-            </div>
+            ))}
         </div>
+    );
+
+    if (displayInline) {
+        return (
+            <aside className="vtk-panel p-5">
+                <h2 className="m-0 mb-4 text-base font-semibold tracking-tight text-vtk-ink">
+                    {t('document.comments.title')}
+                    <span className="ml-2 text-[13px] font-normal text-vtk-muted">({comments.length})</span>
+                </h2>
+                {commentsBody}
+            </aside>
+        );
+    }
+
+    const drawerId = `document-comments-${documentId}`;
+    const isLoadingCount = loading && comments.length === 0;
+
+    return (
+        <>
+            <button
+                type="button"
+                onClick={() => setIsOpen(true)}
+                aria-controls={drawerId}
+                aria-expanded={isOpen}
+                aria-label={isLoadingCount
+                    ? t('document.comments.loading')
+                    : t('document.comments.open', { count: comments.length })}
+                title={t('document.comments.open', { count: comments.length })}
+                className="fixed right-0 top-1/2 z-[8] flex -translate-y-1/2 items-center gap-2 rounded-l-2xl border border-r-0 border-vtk-line-2 bg-vtk-navy px-3 py-3 text-sm font-semibold text-white shadow-[0_12px_32px_rgba(10,15,31,0.22)] transition hover:pr-4 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-vtk-yellow"
+            >
+                <MessageSquarePlus className="h-5 w-5 shrink-0" aria-hidden="true" />
+                <span className="hidden sm:inline">{t('document.comments.title')}</span>
+                <span
+                    aria-live="polite"
+                    className={`grid min-h-6 min-w-6 place-items-center rounded-full px-1.5 text-xs font-bold ${comments.length > 0
+                        ? 'bg-vtk-yellow text-vtk-ink'
+                        : 'bg-white/15 text-white'
+                        }`}
+                >
+                    {isLoadingCount ? '…' : comments.length}
+                </span>
+            </button>
+
+            <Dialog open={isOpen} onClose={setIsOpen} className="relative z-[9]">
+                <DialogBackdrop
+                    transition
+                    className="fixed inset-0 bg-vtk-ink/35 backdrop-blur-xs transition-opacity duration-200 data-closed:opacity-0"
+                />
+                <div className="fixed bottom-0 right-0 top-[72px] flex w-full max-w-[420px]">
+                    <DialogPanel
+                        transition
+                        id={drawerId}
+                        className="h-full w-full overflow-y-auto overscroll-contain border-l border-vtk-line bg-vtk-surface p-5 shadow-[-18px_0_48px_rgba(10,15,31,0.16)] transition duration-300 ease-out data-closed:translate-x-full"
+                    >
+                        <div className="mb-4 flex items-center justify-between gap-4">
+                            <DialogTitle className="m-0 text-lg font-semibold tracking-tight text-vtk-ink">
+                                {t('document.comments.title')}
+                                <span className="ml-2 text-[13px] font-normal text-vtk-muted">
+                                    ({comments.length})
+                                </span>
+                            </DialogTitle>
+                            <button
+                                type="button"
+                                onClick={() => setIsOpen(false)}
+                                className="vtk-icon-button h-9 w-9 shrink-0"
+                                aria-label={t('document.comments.close')}
+                                title={t('document.comments.close')}
+                            >
+                                <X className="h-4 w-4" aria-hidden="true" />
+                            </button>
+                        </div>
+                        {commentsBody}
+                    </DialogPanel>
+                </div>
+            </Dialog>
+        </>
     );
 }

--- a/frontend/src/components/document/DocumentPreview.tsx
+++ b/frontend/src/components/document/DocumentPreview.tsx
@@ -26,6 +26,7 @@ import { useTranslation } from "react-i18next";
 
 // Lazy-load PDFViewer so pdfjs-dist never runs on the server (no DOMMatrix in Node)
 const PDFViewer = dynamic(() => import("@/components/document/pdf/PDFViewer"), { ssr: false });
+const COMMENTS_INLINE_MIN_WIDTH = 1200;
 
 export default function DocumentPreview({ id }: { id: string }) {
     const { t, i18n } = useTranslation();
@@ -38,7 +39,9 @@ export default function DocumentPreview({ id }: { id: string }) {
 
     // Used to scale pdf width to fit its parent container
     const [containerWidth, setContainerWidth] = useState<number>(0);
+    const [showInlineComments, setShowInlineComments] = useState(false);
     const previewRef = useRef<HTMLDivElement>(null);
+    const previewLayoutRef = useRef<HTMLDivElement>(null);
 
     const { user } = useUser();
     const { request, loading, error } = useApi();
@@ -88,6 +91,20 @@ export default function DocumentPreview({ id }: { id: string }) {
         observer.observe(el);
         return () => observer.disconnect();
     }, [document]);
+
+    // Use the actual page area rather than a viewport breakpoint. A wide curriculum sidebar,
+    // browser zoom or OS scaling can make a nominally large laptop just as cramped as a smaller
+    // screen. The comments stay inline only when both columns have genuinely useful space.
+    useEffect(() => {
+        const el = previewLayoutRef.current;
+        if (!el) return;
+
+        const observer = new ResizeObserver(([entry]) => {
+            setShowInlineComments(entry.contentRect.width >= COMMENTS_INLINE_MIN_WIDTH);
+        });
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, [document?.id]);
 
     if (loading) return <LoadingPage />;
 
@@ -147,7 +164,13 @@ export default function DocumentPreview({ id }: { id: string }) {
             )}
 
             {/* Document preview & comment section */}
-            <div className="mt-7 grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+            <div
+                ref={previewLayoutRef}
+                className={`mt-7 grid items-start gap-4 ${showInlineComments
+                    ? 'grid-cols-[minmax(0,1fr)_360px]'
+                    : 'grid-cols-1'
+                    }`}
+            >
                 <div className="vtk-panel overflow-hidden">
                     <div className="flex items-center justify-between gap-3 border-b border-vtk-line px-4 py-3">
                         <VoteButton
@@ -203,7 +226,12 @@ export default function DocumentPreview({ id }: { id: string }) {
                     </div>
                 </div>
 
-                <DocumentCommentSection documentId={document.id} file={document.contentUrl} />
+                <DocumentCommentSection
+                    key={document.id}
+                    documentId={document.id}
+                    file={document.contentUrl}
+                    displayInline={showInlineComments}
+                />
             </div>
         </div>
     )

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -375,7 +375,10 @@
             "anonymous": "Anonymous",
             "success": "Comment added successfully",
             "error": "Failed to add comment",
-            "title": "Comments"
+            "title": "Comments",
+            "open": "Open comments ({{count}})",
+            "close": "Close comments",
+            "loading": "Loading comments"
         },
         "under-review-warning": "This document is currently under review, so it is only visible to you.",
         "author": "Author",

--- a/frontend/src/translations/nl.json
+++ b/frontend/src/translations/nl.json
@@ -375,7 +375,10 @@
             "anonymous": "Anoniem",
             "success": "Opmerking succesvol toegevoegd",
             "error": "Opmerking toevoegen mislukt",
-            "title": "Opmerkingen"
+            "title": "Opmerkingen",
+            "open": "Opmerkingen openen ({{count}})",
+            "close": "Opmerkingen sluiten",
+            "loading": "Opmerkingen laden"
         },
         "under-review-warning": "Dit document is momenteel in behandeling, dus het is alleen zichtbaar voor jou.",
         "author": "Auteur",


### PR DESCRIPTION
## Summary
- measure the actual document content area so sidebar width, browser zoom and display scaling are taken into account
- give compact layouts the full width for the PDF and expose comments through a fixed message tab with a live count
- open comments in an accessible right-side drawer while keeping the existing inline panel on roomy layouts

## Validation
- frontend production build
- frontend ESLint (no errors; one existing LoginForm warning)